### PR TITLE
Adds acceptable price input field and async fetching of chain data.

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -13,41 +13,44 @@
 		<table>
 			<tr>
 				<td style="text-align:right">Price of ETH</td>
-				<td id="eth-price">?</td>
+				<td><ins id="eth-price">?</ins></td>
 			</tr>
 			<tr>
-				<td style="text-align: right">Best ETH:DAI Offer</td>
-				<td id="best-eth-price">?</td>
+				<td style="text-align: right">Acceptable Price of ETH</td>
+				<td id="best-eth-price">
+					<input id="worst-eth-price" type="number" autocomplete="off" autofocus="true" inputmode="decimal" min="0" max="0" step="0.01"
+					 placeholder="?" required="true" tabindex="10" oninput="update()">
+				</td>
 			</tr>
 			<tr>
 				<td style="text-align:right">Leverage Target</td>
 				<td>
 					<input id="leverage-multiplier" type="number" autocomplete="off" autofocus="true" inputmode="decimal" min="1" max="3" step="0.01"
-					 placeholder="2.0" required="true" tabindex="1" oninput="update()">
+					 placeholder="2.0" required="true" tabindex="20" oninput="update()">
 				</td>
 			</tr>
 			<tr>
 				<td style="text-align:right">Liquidation Price</td>
-				<td id="liquidation-price"></td>
+				<td><ins id="liquidation-price">?</ins></td>
 			</tr>
 			<tr>
 				<td style="text-align: right">ETH to Leverage</td>
 				<td>
-					<input id="leverage-size" type="number" autocomplete="off" autofocus inputmode="decimal" min="0" max="1000" step=".0001"
-					 placeholder="1.0" required tabindex="2" oninput="update()">
+					<input id="leverage-size" type="number" autocomplete="off" autofocus="false" inputmode="decimal" min="0" max="1000" step=".0001"
+					 placeholder="1.0" required="true" tabindex="30" oninput="update()">
 				</td>
 			</tr>
 			<tr>
 				<td style="text-align:right">Our Fee (1% of loan)</td>
-				<td id="fee-provider">?</td>
+				<td><ins id="fee-provider">?</ins></td>
 			</tr>
 			<tr>
 				<td style="text-align:right">Exchange Costs</td>
-				<td id="fee-exchange">?</td>
+				<td><ins id="fee-exchange">?</ins></td>
 			</tr>
 			<tr>
-				<td style="text-align: right">Total</td>
-				<td id="fee-total">?</td>
+				<td style="text-align: right">Total ETH</td>
+				<td><ins id="fee-total">?</ins></td>
 			</tr>
 			<tr>
 				<td colspan="2" style="text-align: center">

--- a/client/index.js
+++ b/client/index.js
@@ -1,59 +1,150 @@
-export class CdpOpener {
-	constructor() {
-		// TODO: fetch this periodically from contracts
-		this.priceOfEthInUsd = 500
+const WETH_ADDRESS = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
+const DAI_ADDRESS = '0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359'
+const OASIS_ADDRESS = '0x14fbca95be7e99c15cc2996c6c9d841e54b79425'
 
-		// TODO: update this from contract when user updates leverage-size
-		// TODO: delay updates until 1 second of idle so we don't hammer the server when the user is typing in a multi-digit number
-		// this is the best price we can buy ETH for at the current leverage-size
-		this.bestPriceOfEthInDai = 525
+const DEFAULT_LEVERAGE_MULTIPLIER = 2.0
+const DEFAULT_LEVERAGE_SIZE_IN_ETH = 1
+
+function round(number, precision) {
+	var shift = function (number, precision) {
+		var numArray = ("" + number).split("e");
+		return +(numArray[0] + "e" + (numArray[1] ? (+numArray[1] + precision) : precision));
+	};
+	return shift(Math.round(shift(number, +precision)), -precision);
+}
+
+function randomAround(center, range) {
+	return (Math.random() * range) + center - (range / 2)
+}
+
+function randomAbove(minimum, range) {
+	return (Math.random() * range) + minimum
+}
+
+function randomBelow(maximum, range) {
+	return (Math.random() * range) + maximum - range
+}
+
+async function sleep(milliseconds) {
+	return new Promise(resolve => setTimeout(resolve, milliseconds))
+}
+
+export class Maker {
+	constructor() {
+		this.getEthDaiPrice = async () => {
+			// TODO: return await ???
+			await sleep(randomAround(3000, 2000))
+			return randomAround(500, 25)
+		}
+	}
+}
+
+export class Oasis {
+	constructor(oasisAddress, wethAddress, daiAddress) {
+		this.oasisAddress = oasisAddress
+		this.wethAddress = wethAddress
+		this.daiAddress = daiAddress
+
+		this.getBuyAmount = async (daiToDraw) => {
+			// TODO: return await getBuyAmount(this.wethAddress, this.daiAddress, daiToDraw)
+			await sleep(randomAround(3000, 2000))
+			return daiToDraw / randomAround(500, 50)
+		}
+	}
+}
+
+export class CdpOpener {
+	/**
+	 * @param {Maker} maker
+	 * @param {Oasis} oasis
+	 */
+	constructor(maker, oasis) {
+		this.maker = maker
+		this.oasis = oasis
+
+		this.priceOfEthInUsd = NaN
+		this.estimatedPriceOfEthInDai = NaN
 
 		this.createCdp = () => {
 			if (!document.getElementById('open-cdp-form').checkValidity()) return
 			console.log('TODO: write CDP creation code')
 		}
 
-		this.update = () => {
-			console.log('updating')
-			document.getElementById('eth-price').innerText = this.priceOfEthInUsd
-			// TODO: change best-eth-price to a spinner when we are fetching an updated price
-			document.getElementById('best-eth-price').innerText = this.bestPriceOfEthInDai
-			document.getElementById('liquidation-price').innerText = this.liquidationPrice
-			document.getElementById('fee-provider').innerText = this.providerFee
-			document.getElementById('fee-exchange').innerText = this.exchangeCost
-			document.getElementById('fee-total').innerText = this.totalCost
+		this.updatePriceFeed = async () => {
+			const previous = this.priceOfEthInUsd
+			this.priceOfEthInUsd = await this.maker.getEthDaiPrice()
+			if (this.priceOfEthInUsd === previous) {
+				setTimeout(this.updatePriceFeed, 1000)
+				return
+			}
+			document.getElementById('eth-price').innerText = round(this.priceOfEthInUsd, 2)
+			this.updateDerived()
+			await this.updateDaiSaleProceeds()
+			setTimeout(this.updatePriceFeed, 1000)
 		}
 
-		this.onLoad = (window, event) => {
-			this.update()
+		this.updateDaiSaleProceeds = async () => {
+			const previous = this.estimatedPriceOfEthInDai
+			this.estimatedPriceOfEthInDai = this.daiToDraw / (await this.oasis.getBuyAmount(this.daiToDraw))
+			if (previous === this.estimatedPriceOfEthInDai) return
+			document.getElementById('worst-eth-price').setAttribute('placeholder', round(this.estimatedPriceOfEthInDai, 2))
+			this.updateDerived()
 		}
+
+		this.updateDerived = () => {
+			document.getElementById('worst-eth-price').setAttribute('min', this.priceOfEthInUsd)
+			document.getElementById('worst-eth-price').setAttribute('max', this.priceOfEthInUsd * 2)
+			document.getElementById('liquidation-price').innerText = round(this.liquidationPrice, 2)
+			document.getElementById('fee-provider').innerText = this.providerFee
+			document.getElementById('fee-exchange').innerText = round(this.exchangeCost, this.numberOfEthDecimals)
+			document.getElementById('fee-total').innerText = round(this.totalCost, this.numberOfEthDecimals)
+		}
+
+		this.onLoad = async (window, event) => {
+			this.updatePriceFeed()
+		}
+	}
+
+	get numberOfEthDecimals() {
+		return round(Math.log10(this.priceOfEthInUsd), 0) + 1
 	}
 
 	get leverageMultiplier() {
 		const leverageMultiplier = parseFloat(document.getElementById('leverage-multiplier').value)
-		if (leverageMultiplier < 1 || leverageMultiplier > 3 || isNaN(leverageMultiplier)) return 2
+		if (leverageMultiplier < 1 || leverageMultiplier > 3 || isNaN(leverageMultiplier)) return DEFAULT_LEVERAGE_MULTIPLIER
 		return leverageMultiplier
 	}
 
-	get leverageSize() {
-		const leverageSize = parseFloat(document.getElementById('leverage-size').value)
-		if (leverageSize <= 0 || leverageSize > 1000 || isNaN(leverageSize)) return 1
-		return leverageSize
+	get leverageSizeInEth() {
+		const leverageSizeInEth = parseFloat(document.getElementById('leverage-size').value)
+		if (leverageSizeInEth <= 0 || leverageSizeInEth > 1000 || isNaN(leverageSizeInEth)) return DEFAULT_LEVERAGE_SIZE_IN_ETH
+		return leverageSizeInEth
+	}
+
+	get cdpSizeInEth() {
+		return this.leverageMultiplier * this.leverageSizeInEth
 	}
 
 	get loanSizeInEth() {
-		return this.cdpSizeInEth - this.leverageSize
+		return this.cdpSizeInEth - this.leverageSizeInEth
+	}
+
+	get daiToDraw() {
+		return this.loanSizeInEth * this.priceOfEthInUsd
+	}
+
+	get worstPriceOfEthInDai() {
+		const worstPriceOfEthInDai = parseFloat(document.getElementById('worst-eth-price').value)
+		if (worstPriceOfEthInDai < this.priceOfEthInUsd || isNaN(worstPriceOfEthInDai)) return this.estimatedPriceOfEthInDai
+		return worstPriceOfEthInDai
 	}
 
 	get liquidationPrice() {
 		return 1.5 * this.daiToDraw / this.cdpSizeInEth
 	}
 
-	get cdpSizeInEth() {
-		return this.leverageMultiplier * this.leverageSize
-	}
-	get daiToDraw() {
-		return this.loanSizeInEth * this.priceOfEthInUsd
+	get proceedsOfDaiSaleInEth() {
+		return this.daiToDraw / this.worstPriceOfEthInDai
 	}
 
 	get providerFee() {
@@ -61,17 +152,17 @@ export class CdpOpener {
 	}
 
 	get exchangeCost() {
-		// TODO: pad the price a bit (maybe 5%) to deal with slippage, we will refund the user any excess.
-		const proceedsOfDaiSaleInEth = this.daiToDraw / this.bestPriceOfEthInDai
-		return this.loanSizeInEth - proceedsOfDaiSaleInEth
+		return this.loanSizeInEth - this.proceedsOfDaiSaleInEth
 	}
 
 	get totalCost() {
-		return this.providerFee + this.exchangeCost + this.leverageSize
+		return this.providerFee + this.exchangeCost + this.leverageSizeInEth
 	}
 }
 
-const cdpOpener = new CdpOpener()
+const maker = new Maker()
+const oasis = new Oasis(OASIS_ADDRESS, WETH_ADDRESS, DAI_ADDRESS)
+const cdpOpener = new CdpOpener(maker, oasis)
 window.addEventListener('load', cdpOpener.onLoad, { once: true })
 window.createCdp = cdpOpener.createCdp
-window.update = cdpOpener.update
+window.update = cdpOpener.updateDerived


### PR DESCRIPTION
Most of the work here is behind the scenes, though I did add in some data randomization so you can sit and stare at the UI while it updates with slow-fetch data (to see how it would feel with a poor connection).

I also swapped out the ETH in DAI price and replaced it with an input for "Acceptable Price of ETH".  This allows the user to effectively set a limit on how much of a hit on exchange rate they are willing to take to open the CDP.  It currently auto-populates the hint with the best price available, meaning if they type in what the hint says and the order book doesn't move they'll succeed.  This feels like a useful hint to me as it lets the user know the ballpark of what they should even bother trying for.  Probably valuable to add some tooltips at some point to several of these fields with descriptions.

One interesting thing to note is that if you can acquire ETH off of Oasis for _less_ than Maker's ETH price feed you can open a CDP worth X for less than X.  :D  You can even see this in the UI if you wait for it to randomly generate a couple numbers that are in that direction.

Next step is to either write testing infrastructure or start working on actually fetching data from the blockchain.