### PR TITLE
Adds support for fetching data from parity.zoltu.com

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/node_modules/

--- a/client/index.html
+++ b/client/index.html
@@ -6,11 +6,11 @@
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<link href="index.css" rel="stylesheet" type="text/css" integrity="sha384-OLBgp1GsljhM2TJ+sbHjaiH9txEUvgdDTAzHv2P24donTt6/529l+9Ua0vFImLlb">
-	<script src="index.js" type="module" integrity="sha384-+lA7W1Vom3Dq80H7DqfnwVUhnxUvm23PALG/nZTKT5FYF2DV1P++Hp7hf0ji4arE"></script>
+	<script src="index.js" type="module" integrity="sha384-6AAh3WQMUkvxG6ui9vXFxCdS1Q0kFBI+QWGq8GvQgFCZ6jh8PIjbRJnjv6qlhAxj"></script>
 </head>
 
 <body>
-	<form id="open-cdp-form">
+	<form id="open-cdp-form" onsubmit="return false">
 		<table>
 			<tr>
 				<td style="text-align:right">Official Price of ETH</td>

--- a/deployment/update-integrity.js
+++ b/deployment/update-integrity.js
@@ -1,0 +1,49 @@
+const ssri = require('ssri')
+const fs = require('fs')
+const path = require('path')
+
+async function readFile(path, options) {
+	return new Promise((resolve, reject) => {
+		fs.readFile(path, options, (error, result) => {
+			if (error && !result) {
+				reject(error)
+			} else if (result && !error) {
+				resolve(result)
+			} else {
+				reject(`fs.readFile returned both an error and data!\n${result}\n${error}`)
+			}
+		})
+	})
+}
+
+async function writeFile(path, contents, options) {
+	return new Promise((resolve, reject) => {
+		fs.writeFile(path, contents, options, (error, result) => {
+			if (error) {
+				reject(error)
+			} else {
+				resolve(result)
+			}
+		})
+	})
+}
+
+async function updateIntegrityHash() {
+	const jsFilePath = path.join(__dirname, '../client/index.js')
+	const htmlFilePath = path.join(__dirname, '../client/index.html')
+
+	// calculate the integrity hash for the javascript file
+	const integrity = await ssri.fromStream(fs.createReadStream(jsFilePath, 'utf8'), { algorithms: ['sha384']})
+
+	// replace the integrity hash in the html file
+	const oldHtml = await readFile(htmlFilePath, 'utf8')
+	const newHtml = oldHtml.replace(/<script src="index.js" type="module"[^>]*><\/script>/g, `<script src="index.js" type="module" integrity="${integrity.toString()}"><\/script>`)
+	await writeFile(htmlFilePath, newHtml, 'utf8')
+}
+
+updateIntegrityHash().then(() => {
+	process.exit(0)
+}).catch(error => {
+	console.log(error)
+	process.exit(1)
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,14 @@
+{
+	"name": "liquid-long",
+	"version": "1.0.0",
+	"lockfileVersion": 1,
+	"requires": true,
+	"dependencies": {
+		"ssri": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.0.tgz",
+			"integrity": "sha512-zYOGfVHPhxyzwi8MdtdNyxv3IynWCIM4jYReR48lqu0VngxgH1c+C6CmipRdJ55eVByTJV/gboFEEI7TEQI8DA==",
+			"dev": true
+		}
+	}
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+	"name": "liquid-long",
+	"version": "1.0.0",
+	"main": "client/index.html",
+	"scripts": {
+		"integrity": "node deployment/update-integrity.js"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/Keydonix/liquid-long.git"
+	},
+	"author": "Keydonix",
+	"license": "Unlicense",
+	"bugs": {
+		"url": "https://github.com/Keydonix/liquid-long/issues"
+	},
+	"homepage": "https://github.com/Keydonix/liquid-long#readme",
+	"devDependencies": {
+		"ssri": "6.0.0"
+	}
+}


### PR DESCRIPTION
When a user opens the site without MetaMask, they will now see live pricing data.

* Makes the button not refresh the page.
* Changes `require` to `assert`, since `require` is a reserved function name in node.
* Adds a script for updating the integrity hash in the HTML file.
* Fixes a bug where an assert would fire if the Oasis order book wasn't deep enough to fulfill the desired volume.