### PR TITLE
Turns on TypeScript strict mode and handles insufficient order book depth.

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -6,7 +6,7 @@
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<link href="index.css" rel="stylesheet" type="text/css" integrity="sha384-IWD7iU6LdfgDfxE/K0Q/2yWCWWZqGgmiGEHWrBm6TAS+tMEoqAfDJmI2HRHeM/jq">
-	<script src="index.js" type="module" integrity="sha384-o0zz6dQrItjbXrESirsR0Fnj3NXYqy4s24eVm4dHEaIuIrG/4g2gGxd8EV0pwfNR"></script>
+	<script src="index.js" type="module" integrity="sha384-Hew2iW8ZvNMU31iG3c6TOSDPsa3MywI0fyQGaV7Zf455gsbj/5joDMwzWpUl0SNu"></script>
 </head>
 
 <body>

--- a/client/my.d.ts
+++ b/client/my.d.ts
@@ -40,13 +40,49 @@ interface Window {
 	web3: Web3
 }
 
+type Networks = '1'|'3'|'4'|'42'
+type Modes = 'opening'|'closing'
+type InsufficientDepth = 'insufficient depth'
+
+// null is used to reset a value to its default
 interface StateUpdate {
-	networkId?: '1'|'3'|'4'|'42'
-	account?: string
-	mode?: 'opening'|'closing'
-	priceOfEthInUsd?: number
-	estimatedPriceOfEthInDai?: number
-	limitPriceOfEthInDai?: number
-	leverageMultiplier?: number
-	leverageSizeInEth?: number
+	networkId?: Networks | null
+	account?: string | null
+	mode?: Modes | null
+	priceOfEthInUsd?: number | null
+	estimatedPriceOfEthInDai?: number | InsufficientDepth | null
+	limitPriceOfEthInDai?: number | null
+	leverageMultiplier?: number | null
+	leverageSizeInEth?: number | null
+}
+
+// The following is necessary due to a bug in the TypeScript definition file, can be removed when https://github.com/Keydonix/liquid-long/pull/22 is merged
+interface NumberConstructor {
+	/**
+	 * Returns true if passed value is finite.
+	 * Unlike the global isFinite, Number.isFinite doesn't forcibly convert the parameter to a
+	 * number. Only finite values of the type number, result in true.
+	 * @param value A numeric value.
+	 */
+	isFinite(value: any): value is number;
+
+	/**
+	 * Returns true if the value passed is an integer, false otherwise.
+	 * @param value A numeric value.
+	 */
+	isInteger(value: any): value is number;
+
+	/**
+	 * Returns a Boolean value that indicates whether a value is the reserved value NaN (not a
+	 * number). Unlike the global isNaN(), Number.isNaN() doesn't forcefully convert the parameter
+	 * to a number. Only values of the type number, that are also NaN, result in true.
+	 * @param value A numeric value.
+	 */
+	isNaN(value: any): value is number;
+
+	/**
+	 * Returns true if the value passed is a safe integer.
+	 * @param value A numeric value.
+	 */
+	isSafeInteger(value: any): value is number;
 }

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -6,6 +6,7 @@
 		"checkJs": true,
 		"allowJs": true,
 		"noEmit": true,
+		"strict": true,
 		"lib": [
 			"es2018",
 			"dom",


### PR DESCRIPTION
Enabling TS strict mode is uninteresting, and most of the changes in this PR are just addressing the issues that came up or fixing bugs found by strict mode (there were a couple minor ones).

If the Maker function fails, we interpret this to mean there isn't enough order book depth.  This isn't exactly true, and one day we should find a better solution but for now it is a "good enough" correlation.  When that happens, we assign `'insufficient depth'`to the `estimatedPriceOfEthInDai` variable and use that to determine whether or not we should display a warning sign and tooltip to the user.  This solution works out, but it does require handling that string everywhere `estimatedPriceOfEthInDai` is referenced.