### PR TITLE
Moves all contract calls to LiquidLong.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,17 +7,29 @@
 		{
 			"type": "node",
 			"request": "launch",
-			"name": "Launch Program",
+			"name": "Deploy",
+			"cwd": "${workspaceFolder}/contracts",
 			"runtimeArgs": [ "-r", "ts-node/register", ],
 			"args": [ "${workspaceFolder}/contracts/deployment/scripts/deploy.ts", ],
 			"env": {
-				"TS_NODE_PROJECT": "contracts/deployment/tsconfig.json",
-				"ETHEREUM_HTTP": "http://localhost:8545",
+				"TS_NODE_PROJECT": "${workspaceFolder}/contracts/deployment/tsconfig.json",
+				"ETHEREUM_HTTP": "http://localhost:1235",
 				"ETHEREUM_GAS_PRICE_IN_NANOETH": "1",
 				"ETHEREUM_PRIVATE_KEY": "fae42052f82bed612a724fec3632f325f377120592c75bb78adfcceae6470c5a",
 				"ETHEREUM_OASIS_ADDRESS": "0000000000000000000000000000000000000000",
 				"ETHEREUM_MAKER_ADRESS": "0000000000000000000000000000000000000000",
 			},
+		},
+		{
+			"type": "node",
+			"request": "launch",
+			"name": "Compile",
+			"cwd": "${workspaceFolder}/contracts",
+			"runtimeArgs": [ "-r", "ts-node/register", ],
+			"args": [ "${workspaceFolder}/contracts/deployment/scripts/compile.ts", ],
+			"env": {
+				"TS_NODE_PROJECT": "${workspaceFolder}/contracts/deployment/tsconfig.json",
+			}
 		}
 	]
 }

--- a/contracts/deployment/libraries/Address.ts
+++ b/contracts/deployment/libraries/Address.ts
@@ -11,4 +11,7 @@ export class Address extends ByteArray {
 		if (match === null) throw new Error(`${input} must be a 40 character hex string optionally prefixed with 0x`)
 		return new Address(utils.arrayify(`0x${match[1]}`))
 	}
+	static zero() {
+		return new Address(new Uint8Array(20))
+	}
 }

--- a/contracts/deployment/libraries/ContractCompiler.ts
+++ b/contracts/deployment/libraries/ContractCompiler.ts
@@ -10,15 +10,16 @@ export class ContractCompiler {
 		const compilerInputJson = await this.generateCompilerInput()
 		const compilerOutputJson = compileStandardWrapper(JSON.stringify(compilerInputJson))
 		const compilerOutput: CompilerOutput = JSON.parse(compilerOutputJson);
-		if (compilerOutput.errors) {
-			let errors = "";
+		const errors = (compilerOutput.errors || []).filter(error => !/Experimental features are turned on\. Do not use experimental features on live deployments\./.test(error.message))
+		if (errors) {
+			let concatenatedErrors = "";
 
-			for (let error of compilerOutput.errors) {
-				errors += error.formattedMessage + "\n";
+			for (let error of errors) {
+				concatenatedErrors += error.formattedMessage + "\n";
 			}
 
-			if (errors.length > 0) {
-				throw new Error("The following errors/warnings were returned by solc:\n\n" + errors);
+			if (concatenatedErrors.length > 0) {
+				throw new Error("The following errors/warnings were returned by solc:\n\n" + concatenatedErrors);
 			}
 		}
 

--- a/contracts/source/liquid-long.sol
+++ b/contracts/source/liquid-long.sol
@@ -1,4 +1,5 @@
 pragma solidity 0.4.24;
+pragma experimental ABIEncoderV2;
 
 /**
  * @title ERC20Basic
@@ -192,17 +193,67 @@ contract Maker {
 }
 
 contract LiquidLong is Ownable, Claimable, Pausable {
-	Oasis oasis;
-	Maker maker;
-	Dai dai;
-	Weth weth;
-	Mkr mkr;
+	Oasis public oasis;
+	Maker public maker;
+	Dai private dai;
+	Weth private weth;
+	Mkr private mkr;
+
+	struct CDP {
+		uint256 id;
+		uint256 debtInAttodai;
+		uint256 lockedAttoeth;
+		uint256 feeInAttoeth;
+		uint256 exchangeCostInAttoeth;
+		bool userOwned;
+	}
+
+	CDP[] private cdps;
 
 	constructor(Oasis _oasis, Maker _maker) public {
 		oasis = _oasis;
 		maker = _maker;
-		dai = maker.sai();
-		weth = maker.gem();
-		mkr = maker.gov();
+		// dai = maker.sai();
+		// weth = maker.gem();
+		// mkr = maker.gov();
+
+		cdps.push(CDP({id: 1, debtInAttodai: 500 * 10**18, lockedAttoeth: 1 * 10**18, feeInAttoeth: 0.01 * 10**18, exchangeCostInAttoeth: 0.1 * 10**18, userOwned: true}));
+		cdps.push(CDP({id: 10, debtInAttodai: 0 * 10**18, lockedAttoeth: 1 * 10**18, feeInAttoeth: 0.01 * 10**18, exchangeCostInAttoeth: 0.1 * 10**18, userOwned: false}));
+		cdps.push(CDP({id: 53, debtInAttodai: 1000 * 10**18, lockedAttoeth: 2 * 10**18, feeInAttoeth: 0.01 * 10**18, exchangeCostInAttoeth: 0.1 * 10**18, userOwned: true}));
+		cdps.push(CDP({id: 72, debtInAttodai: 1000 * 10**18, lockedAttoeth: 1 * 10**18, feeInAttoeth: 0.01 * 10**18, exchangeCostInAttoeth: 0.1 * 10**18, userOwned: true}));
+		cdps.push(CDP({id: 999, debtInAttodai: 500 * 10**18, lockedAttoeth: 1 * 10**18, feeInAttoeth: 0.01 * 10**18, exchangeCostInAttoeth: 0.1 * 10**18, userOwned: true}));
+		cdps.push(CDP({id: 1248, debtInAttodai: 750 * 10**18, lockedAttoeth: 1 * 10**18, feeInAttoeth: 0.01 * 10**18, exchangeCostInAttoeth: 0.1 * 10**18, userOwned: true}));
+		cdps.push(CDP({id: 1600, debtInAttodai: 500 * 10**18, lockedAttoeth: 1 * 10**18, feeInAttoeth: 0.01 * 10**18, exchangeCostInAttoeth: 0.1 * 10**18, userOwned: false}));
+	}
+
+	function ethPriceInUsd() public pure returns (uint256 _attousd) {
+		return 500 * 10**18;
+	}
+
+	function estimateDaiSaleProceeds(uint256 _attodaiToSell) public pure returns (uint256 _attoeth) {
+		// TODO: return sentinal value (0) if there isn't enough depth on the books to sell all of the DAI
+		return _attodaiToSell / 510;
+	}
+
+	function getCdps(address /*_user*/, uint256 _offset, uint256 _pageSize) public view returns (CDP[] _cdps) {
+		uint256 _matchCount = 0;
+		for (uint256 _i = 0; _i < cdps.length; ++_i) {
+			if (cdps[_i].id < _offset) continue;
+			if (cdps[_i].id >= _offset + _pageSize) break;
+			++_matchCount;
+		}
+		_cdps = new CDP[](_matchCount);
+		_matchCount = 0;
+		for (_i = 0; _i < cdps.length; ++_i) {
+			if (cdps[_i].id < _offset) continue;
+			if (cdps[_i].id >= _offset + _pageSize) break;
+			_cdps[_matchCount] = cdps[_i];
+			++_matchCount;
+		}
+		return _cdps;
+	}
+
+	function cdpCount() public pure returns (uint256 _cdpCount) {
+		return 2000;
 	}
 }


### PR DESCRIPTION
Gets rid of references to Maker and Oasis contracts in the UI, now only referencing LiquidLong for data.

LiquidLong contract now exports some basic functions for populating the UI.  Right now they return mock data, but the API is "done" for UI/contract data fetching interaction (transaction submission is incomplete).

Made some changes to deployment stuff to get things compiling and deploying with the contract changes, including support for experimental struct returns and fixing a bug with gas estimation during deployment.