### PR TITLE
Fixes bugs, cleans up code, removes dependencies.

### DIFF
--- a/client-library/library/source/generated/liquid-long.ts
+++ b/client-library/library/source/generated/liquid-long.ts
@@ -98,7 +98,7 @@ export class Contract<TBigNumber> {
 		const data = this.encodeMethod(abi, parameters)
 		const transaction = Object.assign({ from: from, to: this.address, data: data }, attachedEth ? { value: attachedEth } : {})
 		const result = await this.dependencies.call(transaction)
-		if (result === '0x') throw new Error(`Call returned '0x' indicating failure.ABI:\n${JSON.stringify(abi)}\nParameters:\n${JSON.stringify(parameters)}`)
+		if (result === '0x') throw new Error(`Call returned '0x' indicating failure.`)
 		return this.dependencies.decodeParams(abi.outputs, result)
 	}
 
@@ -125,7 +125,7 @@ export class CdpHolder<TBigNumber> extends Contract<TBigNumber> {
 	public returnUnrecognizedCdp = async(cdpId: string, user: string, options?: { sender?: string, gasPrice?: TBigNumber }): Promise<void> => {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[{"name":"_cdpId","type":"bytes32"},{"name":"_user","type":"address"}],"name":"returnUnrecognizedCdp","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"}
-		await this.remoteCall(abi, [cdpId, user], "returnUnrecognizedCdp", options.sender, options.gasPrice)
+		await this.remoteCall(abi, [cdpId, user], 'returnUnrecognizedCdp', options.sender, options.gasPrice)
 		return
 	}
 
@@ -133,7 +133,6 @@ export class CdpHolder<TBigNumber> extends Contract<TBigNumber> {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[{"name":"_cdpId","type":"bytes32"},{"name":"_user","type":"address"}],"name":"returnUnrecognizedCdp","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"}
 		await this.localCall(abi, [cdpId, user], options.sender)
-
 	}
 
 	public maker_ = async(options?: { sender?: string }): Promise<string> => {
@@ -146,7 +145,7 @@ export class CdpHolder<TBigNumber> extends Contract<TBigNumber> {
 	public renounceOwnership = async(options?: { sender?: string, gasPrice?: TBigNumber }): Promise<void> => {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[],"name":"renounceOwnership","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"}
-		await this.remoteCall(abi, [], "renounceOwnership", options.sender, options.gasPrice)
+		await this.remoteCall(abi, [], 'renounceOwnership', options.sender, options.gasPrice)
 		return
 	}
 
@@ -154,7 +153,6 @@ export class CdpHolder<TBigNumber> extends Contract<TBigNumber> {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[],"name":"renounceOwnership","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"}
 		await this.localCall(abi, [], options.sender)
-
 	}
 
 	public owner_ = async(options?: { sender?: string }): Promise<string> => {
@@ -167,7 +165,7 @@ export class CdpHolder<TBigNumber> extends Contract<TBigNumber> {
 	public recordCdpOwnership = async(cdpId: string, options?: { sender?: string, gasPrice?: TBigNumber }): Promise<void> => {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[{"name":"_cdpId","type":"bytes32"}],"name":"recordCdpOwnership","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"}
-		await this.remoteCall(abi, [cdpId], "recordCdpOwnership", options.sender, options.gasPrice)
+		await this.remoteCall(abi, [cdpId], 'recordCdpOwnership', options.sender, options.gasPrice)
 		return
 	}
 
@@ -175,13 +173,12 @@ export class CdpHolder<TBigNumber> extends Contract<TBigNumber> {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[{"name":"_cdpId","type":"bytes32"}],"name":"recordCdpOwnership","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"}
 		await this.localCall(abi, [cdpId], options.sender)
-
 	}
 
 	public returnCdp = async(cdpId: string, options?: { sender?: string, gasPrice?: TBigNumber }): Promise<void> => {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[{"name":"_cdpId","type":"bytes32"}],"name":"returnCdp","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"}
-		await this.remoteCall(abi, [cdpId], "returnCdp", options.sender, options.gasPrice)
+		await this.remoteCall(abi, [cdpId], 'returnCdp', options.sender, options.gasPrice)
 		return
 	}
 
@@ -189,7 +186,6 @@ export class CdpHolder<TBigNumber> extends Contract<TBigNumber> {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[{"name":"_cdpId","type":"bytes32"}],"name":"returnCdp","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"}
 		await this.localCall(abi, [cdpId], options.sender)
-
 	}
 
 	public cdpLastOwner_ = async(arg0: string, options?: { sender?: string }): Promise<string> => {
@@ -202,7 +198,7 @@ export class CdpHolder<TBigNumber> extends Contract<TBigNumber> {
 	public transferOwnership = async(newOwner: string, options?: { sender?: string, gasPrice?: TBigNumber }): Promise<void> => {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[{"name":"newOwner","type":"address"}],"name":"transferOwnership","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"}
-		await this.remoteCall(abi, [newOwner], "transferOwnership", options.sender, options.gasPrice)
+		await this.remoteCall(abi, [newOwner], 'transferOwnership', options.sender, options.gasPrice)
 		return
 	}
 
@@ -210,7 +206,6 @@ export class CdpHolder<TBigNumber> extends Contract<TBigNumber> {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[{"name":"newOwner","type":"address"}],"name":"transferOwnership","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"}
 		await this.localCall(abi, [newOwner], options.sender)
-
 	}
 }
 
@@ -223,7 +218,7 @@ export class Claimable<TBigNumber> extends Contract<TBigNumber> {
 	public claimOwnership = async(options?: { sender?: string, gasPrice?: TBigNumber }): Promise<void> => {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[],"name":"claimOwnership","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"}
-		await this.remoteCall(abi, [], "claimOwnership", options.sender, options.gasPrice)
+		await this.remoteCall(abi, [], 'claimOwnership', options.sender, options.gasPrice)
 		return
 	}
 
@@ -231,13 +226,12 @@ export class Claimable<TBigNumber> extends Contract<TBigNumber> {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[],"name":"claimOwnership","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"}
 		await this.localCall(abi, [], options.sender)
-
 	}
 
 	public renounceOwnership = async(options?: { sender?: string, gasPrice?: TBigNumber }): Promise<void> => {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[],"name":"renounceOwnership","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"}
-		await this.remoteCall(abi, [], "renounceOwnership", options.sender, options.gasPrice)
+		await this.remoteCall(abi, [], 'renounceOwnership', options.sender, options.gasPrice)
 		return
 	}
 
@@ -245,7 +239,6 @@ export class Claimable<TBigNumber> extends Contract<TBigNumber> {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[],"name":"renounceOwnership","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"}
 		await this.localCall(abi, [], options.sender)
-
 	}
 
 	public owner_ = async(options?: { sender?: string }): Promise<string> => {
@@ -265,7 +258,7 @@ export class Claimable<TBigNumber> extends Contract<TBigNumber> {
 	public transferOwnership = async(newOwner: string, options?: { sender?: string, gasPrice?: TBigNumber }): Promise<void> => {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[{"name":"newOwner","type":"address"}],"name":"transferOwnership","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"}
-		await this.remoteCall(abi, [newOwner], "transferOwnership", options.sender, options.gasPrice)
+		await this.remoteCall(abi, [newOwner], 'transferOwnership', options.sender, options.gasPrice)
 		return
 	}
 
@@ -273,7 +266,6 @@ export class Claimable<TBigNumber> extends Contract<TBigNumber> {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[{"name":"newOwner","type":"address"}],"name":"transferOwnership","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"}
 		await this.localCall(abi, [newOwner], options.sender)
-
 	}
 }
 
@@ -286,7 +278,7 @@ export class Dai<TBigNumber> extends Contract<TBigNumber> {
 	public approve = async(spender: string, value: TBigNumber, options?: { sender?: string, gasPrice?: TBigNumber }): Promise<void> => {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[{"name":"spender","type":"address"},{"name":"value","type":"uint256"}],"name":"approve","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"}
-		await this.remoteCall(abi, [spender, value], "approve", options.sender, options.gasPrice)
+		await this.remoteCall(abi, [spender, value], 'approve', options.sender, options.gasPrice)
 		return
 	}
 
@@ -307,7 +299,7 @@ export class Dai<TBigNumber> extends Contract<TBigNumber> {
 	public transferFrom = async(from: string, to: string, value: TBigNumber, options?: { sender?: string, gasPrice?: TBigNumber }): Promise<void> => {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[{"name":"from","type":"address"},{"name":"to","type":"address"},{"name":"value","type":"uint256"}],"name":"transferFrom","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"}
-		await this.remoteCall(abi, [from, to, value], "transferFrom", options.sender, options.gasPrice)
+		await this.remoteCall(abi, [from, to, value], 'transferFrom', options.sender, options.gasPrice)
 		return
 	}
 
@@ -328,7 +320,7 @@ export class Dai<TBigNumber> extends Contract<TBigNumber> {
 	public transfer = async(to: string, value: TBigNumber, options?: { sender?: string, gasPrice?: TBigNumber }): Promise<void> => {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[{"name":"to","type":"address"},{"name":"value","type":"uint256"}],"name":"transfer","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"}
-		await this.remoteCall(abi, [to, value], "transfer", options.sender, options.gasPrice)
+		await this.remoteCall(abi, [to, value], 'transfer', options.sender, options.gasPrice)
 		return
 	}
 
@@ -356,7 +348,7 @@ export class ERC20<TBigNumber> extends Contract<TBigNumber> {
 	public approve = async(spender: string, value: TBigNumber, options?: { sender?: string, gasPrice?: TBigNumber }): Promise<void> => {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[{"name":"spender","type":"address"},{"name":"value","type":"uint256"}],"name":"approve","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"}
-		await this.remoteCall(abi, [spender, value], "approve", options.sender, options.gasPrice)
+		await this.remoteCall(abi, [spender, value], 'approve', options.sender, options.gasPrice)
 		return
 	}
 
@@ -377,7 +369,7 @@ export class ERC20<TBigNumber> extends Contract<TBigNumber> {
 	public transferFrom = async(from: string, to: string, value: TBigNumber, options?: { sender?: string, gasPrice?: TBigNumber }): Promise<void> => {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[{"name":"from","type":"address"},{"name":"to","type":"address"},{"name":"value","type":"uint256"}],"name":"transferFrom","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"}
-		await this.remoteCall(abi, [from, to, value], "transferFrom", options.sender, options.gasPrice)
+		await this.remoteCall(abi, [from, to, value], 'transferFrom', options.sender, options.gasPrice)
 		return
 	}
 
@@ -398,7 +390,7 @@ export class ERC20<TBigNumber> extends Contract<TBigNumber> {
 	public transfer = async(to: string, value: TBigNumber, options?: { sender?: string, gasPrice?: TBigNumber }): Promise<void> => {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[{"name":"to","type":"address"},{"name":"value","type":"uint256"}],"name":"transfer","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"}
-		await this.remoteCall(abi, [to, value], "transfer", options.sender, options.gasPrice)
+		await this.remoteCall(abi, [to, value], 'transfer', options.sender, options.gasPrice)
 		return
 	}
 
@@ -440,7 +432,7 @@ export class ERC20Basic<TBigNumber> extends Contract<TBigNumber> {
 	public transfer = async(to: string, value: TBigNumber, options?: { sender?: string, gasPrice?: TBigNumber }): Promise<void> => {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[{"name":"to","type":"address"},{"name":"value","type":"uint256"}],"name":"transfer","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"}
-		await this.remoteCall(abi, [to, value], "transfer", options.sender, options.gasPrice)
+		await this.remoteCall(abi, [to, value], 'transfer', options.sender, options.gasPrice)
 		return
 	}
 
@@ -468,7 +460,7 @@ export class LiquidLong<TBigNumber> extends Contract<TBigNumber> {
 	public getCdps = async(user: string, offset: TBigNumber, pageSize: TBigNumber, options?: { sender?: string, gasPrice?: TBigNumber }): Promise<void> => {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[{"name":"_user","type":"address"},{"name":"_offset","type":"uint256"},{"name":"_pageSize","type":"uint256"}],"name":"getCdps","outputs":[{"components":[{"name":"id","type":"uint256"},{"name":"debtInAttodai","type":"uint256"},{"name":"lockedAttoeth","type":"uint256"},{"name":"feeInAttoeth","type":"uint256"},{"name":"liquidationCostInAttoeth","type":"uint256"},{"name":"liquidatableDebtInAttodai","type":"uint256"},{"name":"liquidationCostAtFeedPriceInAttoeth","type":"uint256"},{"name":"userOwned","type":"bool"}],"name":"_cdps","type":"tuple[]"}],"payable":false,"stateMutability":"nonpayable","type":"function"}
-		await this.remoteCall(abi, [user, offset, pageSize], "getCdps", options.sender, options.gasPrice)
+		await this.remoteCall(abi, [user, offset, pageSize], 'getCdps', options.sender, options.gasPrice)
 		return
 	}
 
@@ -482,7 +474,7 @@ export class LiquidLong<TBigNumber> extends Contract<TBigNumber> {
 	public closeCdp = async(cdpId: string, options?: { sender?: string, gasPrice?: TBigNumber, attachedEth?: TBigNumber }): Promise<void> => {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[{"name":"_cdpId","type":"bytes32"}],"name":"closeCdp","outputs":[{"name":"","type":"uint256"}],"payable":true,"stateMutability":"payable","type":"function"}
-		await this.remoteCall(abi, [cdpId], "closeCdp", options.sender, options.gasPrice, options.attachedEth)
+		await this.remoteCall(abi, [cdpId], 'closeCdp', options.sender, options.gasPrice, options.attachedEth)
 		return
 	}
 
@@ -503,7 +495,7 @@ export class LiquidLong<TBigNumber> extends Contract<TBigNumber> {
 	public wethDeposit = async(options?: { sender?: string, gasPrice?: TBigNumber, attachedEth?: TBigNumber }): Promise<void> => {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[],"name":"wethDeposit","outputs":[],"payable":true,"stateMutability":"payable","type":"function"}
-		await this.remoteCall(abi, [], "wethDeposit", options.sender, options.gasPrice, options.attachedEth)
+		await this.remoteCall(abi, [], 'wethDeposit', options.sender, options.gasPrice, options.attachedEth)
 		return
 	}
 
@@ -511,13 +503,12 @@ export class LiquidLong<TBigNumber> extends Contract<TBigNumber> {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[],"name":"wethDeposit","outputs":[],"payable":true,"stateMutability":"payable","type":"function"}
 		await this.localCall(abi, [], options.sender, options.attachedEth)
-
 	}
 
 	public unpause = async(options?: { sender?: string, gasPrice?: TBigNumber }): Promise<void> => {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[],"name":"unpause","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"}
-		await this.remoteCall(abi, [], "unpause", options.sender, options.gasPrice)
+		await this.remoteCall(abi, [], 'unpause', options.sender, options.gasPrice)
 		return
 	}
 
@@ -525,7 +516,6 @@ export class LiquidLong<TBigNumber> extends Contract<TBigNumber> {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[],"name":"unpause","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"}
 		await this.localCall(abi, [], options.sender)
-
 	}
 
 	public estimateDaiPurchaseCosts_ = async(attodaiToBuy: TBigNumber, options?: { sender?: string }): Promise<{_wethPaid: TBigNumber, _daiBought: TBigNumber}> => {
@@ -545,7 +535,7 @@ export class LiquidLong<TBigNumber> extends Contract<TBigNumber> {
 	public returnUnrecognizedCdp = async(cdpId: string, user: string, options?: { sender?: string, gasPrice?: TBigNumber }): Promise<void> => {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[{"name":"_cdpId","type":"bytes32"},{"name":"_user","type":"address"}],"name":"returnUnrecognizedCdp","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"}
-		await this.remoteCall(abi, [cdpId, user], "returnUnrecognizedCdp", options.sender, options.gasPrice)
+		await this.remoteCall(abi, [cdpId, user], 'returnUnrecognizedCdp', options.sender, options.gasPrice)
 		return
 	}
 
@@ -553,13 +543,12 @@ export class LiquidLong<TBigNumber> extends Contract<TBigNumber> {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[{"name":"_cdpId","type":"bytes32"},{"name":"_user","type":"address"}],"name":"returnUnrecognizedCdp","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"}
 		await this.localCall(abi, [cdpId, user], options.sender)
-
 	}
 
 	public claimOwnership = async(options?: { sender?: string, gasPrice?: TBigNumber }): Promise<void> => {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[],"name":"claimOwnership","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"}
-		await this.remoteCall(abi, [], "claimOwnership", options.sender, options.gasPrice)
+		await this.remoteCall(abi, [], 'claimOwnership', options.sender, options.gasPrice)
 		return
 	}
 
@@ -567,7 +556,6 @@ export class LiquidLong<TBigNumber> extends Contract<TBigNumber> {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[],"name":"claimOwnership","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"}
 		await this.localCall(abi, [], options.sender)
-
 	}
 
 	public maker_ = async(options?: { sender?: string }): Promise<string> => {
@@ -594,7 +582,7 @@ export class LiquidLong<TBigNumber> extends Contract<TBigNumber> {
 	public withdrawPayments = async(options?: { sender?: string, gasPrice?: TBigNumber }): Promise<void> => {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[],"name":"withdrawPayments","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"}
-		await this.remoteCall(abi, [], "withdrawPayments", options.sender, options.gasPrice)
+		await this.remoteCall(abi, [], 'withdrawPayments', options.sender, options.gasPrice)
 		return
 	}
 
@@ -602,7 +590,6 @@ export class LiquidLong<TBigNumber> extends Contract<TBigNumber> {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[],"name":"withdrawPayments","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"}
 		await this.localCall(abi, [], options.sender)
-
 	}
 
 	public ethPriceInUsd_ = async(options?: { sender?: string }): Promise<TBigNumber> => {
@@ -615,7 +602,7 @@ export class LiquidLong<TBigNumber> extends Contract<TBigNumber> {
 	public renounceOwnership = async(options?: { sender?: string, gasPrice?: TBigNumber }): Promise<void> => {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[],"name":"renounceOwnership","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"}
-		await this.remoteCall(abi, [], "renounceOwnership", options.sender, options.gasPrice)
+		await this.remoteCall(abi, [], 'renounceOwnership', options.sender, options.gasPrice)
 		return
 	}
 
@@ -623,7 +610,6 @@ export class LiquidLong<TBigNumber> extends Contract<TBigNumber> {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[],"name":"renounceOwnership","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"}
 		await this.localCall(abi, [], options.sender)
-
 	}
 
 	public getBuyPriceAndAmount_ = async(payGem: string, buyGem: string, buyDesiredAmount: TBigNumber, options?: { sender?: string }): Promise<{_paidAmount: TBigNumber, _boughtAmount: TBigNumber}> => {
@@ -636,7 +622,7 @@ export class LiquidLong<TBigNumber> extends Contract<TBigNumber> {
 	public openCdp = async(leverage: TBigNumber, leverageSizeInAttoeth: TBigNumber, allowedFeeInAttoeth: TBigNumber, affiliateFeeInAttoeth: TBigNumber, affiliateAddress: string, options?: { sender?: string, gasPrice?: TBigNumber, attachedEth?: TBigNumber }): Promise<void> => {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[{"name":"_leverage","type":"uint256"},{"name":"_leverageSizeInAttoeth","type":"uint256"},{"name":"_allowedFeeInAttoeth","type":"uint256"},{"name":"_affiliateFeeInAttoeth","type":"uint256"},{"name":"_affiliateAddress","type":"address"}],"name":"openCdp","outputs":[{"name":"_cdpId","type":"bytes32"}],"payable":true,"stateMutability":"payable","type":"function"}
-		await this.remoteCall(abi, [leverage, leverageSizeInAttoeth, allowedFeeInAttoeth, affiliateFeeInAttoeth, affiliateAddress], "openCdp", options.sender, options.gasPrice, options.attachedEth)
+		await this.remoteCall(abi, [leverage, leverageSizeInAttoeth, allowedFeeInAttoeth, affiliateFeeInAttoeth, affiliateAddress], 'openCdp', options.sender, options.gasPrice, options.attachedEth)
 		return
 	}
 
@@ -650,7 +636,7 @@ export class LiquidLong<TBigNumber> extends Contract<TBigNumber> {
 	public pause = async(options?: { sender?: string, gasPrice?: TBigNumber }): Promise<void> => {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[],"name":"pause","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"}
-		await this.remoteCall(abi, [], "pause", options.sender, options.gasPrice)
+		await this.remoteCall(abi, [], 'pause', options.sender, options.gasPrice)
 		return
 	}
 
@@ -658,7 +644,6 @@ export class LiquidLong<TBigNumber> extends Contract<TBigNumber> {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[],"name":"pause","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"}
 		await this.localCall(abi, [], options.sender)
-
 	}
 
 	public owner_ = async(options?: { sender?: string }): Promise<string> => {
@@ -671,7 +656,7 @@ export class LiquidLong<TBigNumber> extends Contract<TBigNumber> {
 	public wethWithdraw = async(amount: TBigNumber, options?: { sender?: string, gasPrice?: TBigNumber }): Promise<void> => {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[{"name":"amount","type":"uint256"}],"name":"wethWithdraw","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"}
-		await this.remoteCall(abi, [amount], "wethWithdraw", options.sender, options.gasPrice)
+		await this.remoteCall(abi, [amount], 'wethWithdraw', options.sender, options.gasPrice)
 		return
 	}
 
@@ -679,13 +664,12 @@ export class LiquidLong<TBigNumber> extends Contract<TBigNumber> {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[{"name":"amount","type":"uint256"}],"name":"wethWithdraw","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"}
 		await this.localCall(abi, [amount], options.sender)
-
 	}
 
 	public recordCdpOwnership = async(cdpId: string, options?: { sender?: string, gasPrice?: TBigNumber }): Promise<void> => {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[{"name":"_cdpId","type":"bytes32"}],"name":"recordCdpOwnership","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"}
-		await this.remoteCall(abi, [cdpId], "recordCdpOwnership", options.sender, options.gasPrice)
+		await this.remoteCall(abi, [cdpId], 'recordCdpOwnership', options.sender, options.gasPrice)
 		return
 	}
 
@@ -693,7 +677,6 @@ export class LiquidLong<TBigNumber> extends Contract<TBigNumber> {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[{"name":"_cdpId","type":"bytes32"}],"name":"recordCdpOwnership","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"}
 		await this.localCall(abi, [cdpId], options.sender)
-
 	}
 
 	public oasis_ = async(options?: { sender?: string }): Promise<string> => {
@@ -706,7 +689,7 @@ export class LiquidLong<TBigNumber> extends Contract<TBigNumber> {
 	public returnCdp = async(cdpId: string, options?: { sender?: string, gasPrice?: TBigNumber }): Promise<void> => {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[{"name":"_cdpId","type":"bytes32"}],"name":"returnCdp","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"}
-		await this.remoteCall(abi, [cdpId], "returnCdp", options.sender, options.gasPrice)
+		await this.remoteCall(abi, [cdpId], 'returnCdp', options.sender, options.gasPrice)
 		return
 	}
 
@@ -714,7 +697,6 @@ export class LiquidLong<TBigNumber> extends Contract<TBigNumber> {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[{"name":"_cdpId","type":"bytes32"}],"name":"returnCdp","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"}
 		await this.localCall(abi, [cdpId], options.sender)
-
 	}
 
 	public cdpLastOwner_ = async(arg0: string, options?: { sender?: string }): Promise<string> => {
@@ -748,7 +730,7 @@ export class LiquidLong<TBigNumber> extends Contract<TBigNumber> {
 	public transferOwnership = async(newOwner: string, options?: { sender?: string, gasPrice?: TBigNumber }): Promise<void> => {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[{"name":"newOwner","type":"address"}],"name":"transferOwnership","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"}
-		await this.remoteCall(abi, [newOwner], "transferOwnership", options.sender, options.gasPrice)
+		await this.remoteCall(abi, [newOwner], 'transferOwnership', options.sender, options.gasPrice)
 		return
 	}
 
@@ -756,7 +738,6 @@ export class LiquidLong<TBigNumber> extends Contract<TBigNumber> {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[{"name":"newOwner","type":"address"}],"name":"transferOwnership","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"}
 		await this.localCall(abi, [newOwner], options.sender)
-
 	}
 
 	public providerFeePerEth_ = async(options?: { sender?: string }): Promise<TBigNumber> => {
@@ -776,7 +757,7 @@ export class Maker<TBigNumber> extends Contract<TBigNumber> {
 	public join = async(wad: TBigNumber, options?: { sender?: string, gasPrice?: TBigNumber }): Promise<void> => {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[{"name":"wad","type":"uint256"}],"name":"join","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"}
-		await this.remoteCall(abi, [wad], "join", options.sender, options.gasPrice)
+		await this.remoteCall(abi, [wad], 'join', options.sender, options.gasPrice)
 		return
 	}
 
@@ -784,7 +765,6 @@ export class Maker<TBigNumber> extends Contract<TBigNumber> {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[{"name":"wad","type":"uint256"}],"name":"join","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"}
 		await this.localCall(abi, [wad], options.sender)
-
 	}
 
 	public skr_ = async(options?: { sender?: string }): Promise<string> => {
@@ -804,7 +784,7 @@ export class Maker<TBigNumber> extends Contract<TBigNumber> {
 	public ink = async(cup: string, options?: { sender?: string, gasPrice?: TBigNumber }): Promise<void> => {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[{"name":"cup","type":"bytes32"}],"name":"ink","outputs":[{"name":"","type":"uint256"}],"payable":false,"stateMutability":"nonpayable","type":"function"}
-		await this.remoteCall(abi, [cup], "ink", options.sender, options.gasPrice)
+		await this.remoteCall(abi, [cup], 'ink', options.sender, options.gasPrice)
 		return
 	}
 
@@ -818,7 +798,7 @@ export class Maker<TBigNumber> extends Contract<TBigNumber> {
 	public draw = async(cup: string, wad: TBigNumber, options?: { sender?: string, gasPrice?: TBigNumber }): Promise<void> => {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[{"name":"cup","type":"bytes32"},{"name":"wad","type":"uint256"}],"name":"draw","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"}
-		await this.remoteCall(abi, [cup, wad], "draw", options.sender, options.gasPrice)
+		await this.remoteCall(abi, [cup, wad], 'draw', options.sender, options.gasPrice)
 		return
 	}
 
@@ -826,7 +806,6 @@ export class Maker<TBigNumber> extends Contract<TBigNumber> {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[{"name":"cup","type":"bytes32"},{"name":"wad","type":"uint256"}],"name":"draw","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"}
 		await this.localCall(abi, [cup, wad], options.sender)
-
 	}
 
 	public cupi_ = async(options?: { sender?: string }): Promise<TBigNumber> => {
@@ -846,7 +825,7 @@ export class Maker<TBigNumber> extends Contract<TBigNumber> {
 	public rap = async(cup: string, options?: { sender?: string, gasPrice?: TBigNumber }): Promise<void> => {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[{"name":"cup","type":"bytes32"}],"name":"rap","outputs":[{"name":"","type":"uint256"}],"payable":false,"stateMutability":"nonpayable","type":"function"}
-		await this.remoteCall(abi, [cup], "rap", options.sender, options.gasPrice)
+		await this.remoteCall(abi, [cup], 'rap', options.sender, options.gasPrice)
 		return
 	}
 
@@ -860,7 +839,7 @@ export class Maker<TBigNumber> extends Contract<TBigNumber> {
 	public wipe = async(cup: string, wad: TBigNumber, options?: { sender?: string, gasPrice?: TBigNumber }): Promise<void> => {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[{"name":"cup","type":"bytes32"},{"name":"wad","type":"uint256"}],"name":"wipe","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"}
-		await this.remoteCall(abi, [cup, wad], "wipe", options.sender, options.gasPrice)
+		await this.remoteCall(abi, [cup, wad], 'wipe', options.sender, options.gasPrice)
 		return
 	}
 
@@ -868,7 +847,6 @@ export class Maker<TBigNumber> extends Contract<TBigNumber> {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[{"name":"cup","type":"bytes32"},{"name":"wad","type":"uint256"}],"name":"wipe","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"}
 		await this.localCall(abi, [cup, wad], options.sender)
-
 	}
 
 	public gem_ = async(options?: { sender?: string }): Promise<string> => {
@@ -895,7 +873,7 @@ export class Maker<TBigNumber> extends Contract<TBigNumber> {
 	public lock = async(cup: string, wad: TBigNumber, options?: { sender?: string, gasPrice?: TBigNumber }): Promise<void> => {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[{"name":"cup","type":"bytes32"},{"name":"wad","type":"uint256"}],"name":"lock","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"}
-		await this.remoteCall(abi, [cup, wad], "lock", options.sender, options.gasPrice)
+		await this.remoteCall(abi, [cup, wad], 'lock', options.sender, options.gasPrice)
 		return
 	}
 
@@ -903,13 +881,12 @@ export class Maker<TBigNumber> extends Contract<TBigNumber> {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[{"name":"cup","type":"bytes32"},{"name":"wad","type":"uint256"}],"name":"lock","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"}
 		await this.localCall(abi, [cup, wad], options.sender)
-
 	}
 
 	public give = async(cup: string, guy: string, options?: { sender?: string, gasPrice?: TBigNumber }): Promise<void> => {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[{"name":"cup","type":"bytes32"},{"name":"guy","type":"address"}],"name":"give","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"}
-		await this.remoteCall(abi, [cup, guy], "give", options.sender, options.gasPrice)
+		await this.remoteCall(abi, [cup, guy], 'give', options.sender, options.gasPrice)
 		return
 	}
 
@@ -917,13 +894,12 @@ export class Maker<TBigNumber> extends Contract<TBigNumber> {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[{"name":"cup","type":"bytes32"},{"name":"guy","type":"address"}],"name":"give","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"}
 		await this.localCall(abi, [cup, guy], options.sender)
-
 	}
 
 	public chi = async(options?: { sender?: string, gasPrice?: TBigNumber }): Promise<void> => {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[],"name":"chi","outputs":[{"name":"","type":"uint256"}],"payable":false,"stateMutability":"nonpayable","type":"function"}
-		await this.remoteCall(abi, [], "chi", options.sender, options.gasPrice)
+		await this.remoteCall(abi, [], 'chi', options.sender, options.gasPrice)
 		return
 	}
 
@@ -951,7 +927,7 @@ export class Maker<TBigNumber> extends Contract<TBigNumber> {
 	public tab = async(cup: string, options?: { sender?: string, gasPrice?: TBigNumber }): Promise<void> => {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[{"name":"cup","type":"bytes32"}],"name":"tab","outputs":[{"name":"","type":"uint256"}],"payable":false,"stateMutability":"nonpayable","type":"function"}
-		await this.remoteCall(abi, [cup], "tab", options.sender, options.gasPrice)
+		await this.remoteCall(abi, [cup], 'tab', options.sender, options.gasPrice)
 		return
 	}
 
@@ -965,7 +941,7 @@ export class Maker<TBigNumber> extends Contract<TBigNumber> {
 	public open = async(options?: { sender?: string, gasPrice?: TBigNumber }): Promise<void> => {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[],"name":"open","outputs":[{"name":"cup","type":"bytes32"}],"payable":false,"stateMutability":"nonpayable","type":"function"}
-		await this.remoteCall(abi, [], "open", options.sender, options.gasPrice)
+		await this.remoteCall(abi, [], 'open', options.sender, options.gasPrice)
 		return
 	}
 
@@ -1007,7 +983,7 @@ export class Mkr<TBigNumber> extends Contract<TBigNumber> {
 	public approve = async(spender: string, value: TBigNumber, options?: { sender?: string, gasPrice?: TBigNumber }): Promise<void> => {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[{"name":"spender","type":"address"},{"name":"value","type":"uint256"}],"name":"approve","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"}
-		await this.remoteCall(abi, [spender, value], "approve", options.sender, options.gasPrice)
+		await this.remoteCall(abi, [spender, value], 'approve', options.sender, options.gasPrice)
 		return
 	}
 
@@ -1028,7 +1004,7 @@ export class Mkr<TBigNumber> extends Contract<TBigNumber> {
 	public transferFrom = async(from: string, to: string, value: TBigNumber, options?: { sender?: string, gasPrice?: TBigNumber }): Promise<void> => {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[{"name":"from","type":"address"},{"name":"to","type":"address"},{"name":"value","type":"uint256"}],"name":"transferFrom","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"}
-		await this.remoteCall(abi, [from, to, value], "transferFrom", options.sender, options.gasPrice)
+		await this.remoteCall(abi, [from, to, value], 'transferFrom', options.sender, options.gasPrice)
 		return
 	}
 
@@ -1049,7 +1025,7 @@ export class Mkr<TBigNumber> extends Contract<TBigNumber> {
 	public transfer = async(to: string, value: TBigNumber, options?: { sender?: string, gasPrice?: TBigNumber }): Promise<void> => {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[{"name":"to","type":"address"},{"name":"value","type":"uint256"}],"name":"transfer","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"}
-		await this.remoteCall(abi, [to, value], "transfer", options.sender, options.gasPrice)
+		await this.remoteCall(abi, [to, value], 'transfer', options.sender, options.gasPrice)
 		return
 	}
 
@@ -1084,7 +1060,7 @@ export class Oasis<TBigNumber> extends Contract<TBigNumber> {
 	public sellAllAmount = async(pay_gem: string, pay_amt: TBigNumber, buy_gem: string, min_fill_amount: TBigNumber, options?: { sender?: string, gasPrice?: TBigNumber }): Promise<void> => {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[{"name":"pay_gem","type":"address"},{"name":"pay_amt","type":"uint256"},{"name":"buy_gem","type":"address"},{"name":"min_fill_amount","type":"uint256"}],"name":"sellAllAmount","outputs":[{"name":"fill_amt","type":"uint256"}],"payable":false,"stateMutability":"nonpayable","type":"function"}
-		await this.remoteCall(abi, [pay_gem, pay_amt, buy_gem, min_fill_amount], "sellAllAmount", options.sender, options.gasPrice)
+		await this.remoteCall(abi, [pay_gem, pay_amt, buy_gem, min_fill_amount], 'sellAllAmount', options.sender, options.gasPrice)
 		return
 	}
 
@@ -1133,7 +1109,7 @@ export class Ownable<TBigNumber> extends Contract<TBigNumber> {
 	public renounceOwnership = async(options?: { sender?: string, gasPrice?: TBigNumber }): Promise<void> => {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[],"name":"renounceOwnership","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"}
-		await this.remoteCall(abi, [], "renounceOwnership", options.sender, options.gasPrice)
+		await this.remoteCall(abi, [], 'renounceOwnership', options.sender, options.gasPrice)
 		return
 	}
 
@@ -1141,7 +1117,6 @@ export class Ownable<TBigNumber> extends Contract<TBigNumber> {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[],"name":"renounceOwnership","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"}
 		await this.localCall(abi, [], options.sender)
-
 	}
 
 	public owner_ = async(options?: { sender?: string }): Promise<string> => {
@@ -1154,7 +1129,7 @@ export class Ownable<TBigNumber> extends Contract<TBigNumber> {
 	public transferOwnership = async(newOwner: string, options?: { sender?: string, gasPrice?: TBigNumber }): Promise<void> => {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[{"name":"newOwner","type":"address"}],"name":"transferOwnership","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"}
-		await this.remoteCall(abi, [newOwner], "transferOwnership", options.sender, options.gasPrice)
+		await this.remoteCall(abi, [newOwner], 'transferOwnership', options.sender, options.gasPrice)
 		return
 	}
 
@@ -1162,7 +1137,6 @@ export class Ownable<TBigNumber> extends Contract<TBigNumber> {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[{"name":"newOwner","type":"address"}],"name":"transferOwnership","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"}
 		await this.localCall(abi, [newOwner], options.sender)
-
 	}
 }
 
@@ -1175,7 +1149,7 @@ export class Pausable<TBigNumber> extends Contract<TBigNumber> {
 	public unpause = async(options?: { sender?: string, gasPrice?: TBigNumber }): Promise<void> => {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[],"name":"unpause","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"}
-		await this.remoteCall(abi, [], "unpause", options.sender, options.gasPrice)
+		await this.remoteCall(abi, [], 'unpause', options.sender, options.gasPrice)
 		return
 	}
 
@@ -1183,7 +1157,6 @@ export class Pausable<TBigNumber> extends Contract<TBigNumber> {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[],"name":"unpause","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"}
 		await this.localCall(abi, [], options.sender)
-
 	}
 
 	public paused_ = async(options?: { sender?: string }): Promise<boolean> => {
@@ -1196,7 +1169,7 @@ export class Pausable<TBigNumber> extends Contract<TBigNumber> {
 	public renounceOwnership = async(options?: { sender?: string, gasPrice?: TBigNumber }): Promise<void> => {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[],"name":"renounceOwnership","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"}
-		await this.remoteCall(abi, [], "renounceOwnership", options.sender, options.gasPrice)
+		await this.remoteCall(abi, [], 'renounceOwnership', options.sender, options.gasPrice)
 		return
 	}
 
@@ -1204,13 +1177,12 @@ export class Pausable<TBigNumber> extends Contract<TBigNumber> {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[],"name":"renounceOwnership","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"}
 		await this.localCall(abi, [], options.sender)
-
 	}
 
 	public pause = async(options?: { sender?: string, gasPrice?: TBigNumber }): Promise<void> => {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[],"name":"pause","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"}
-		await this.remoteCall(abi, [], "pause", options.sender, options.gasPrice)
+		await this.remoteCall(abi, [], 'pause', options.sender, options.gasPrice)
 		return
 	}
 
@@ -1218,7 +1190,6 @@ export class Pausable<TBigNumber> extends Contract<TBigNumber> {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[],"name":"pause","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"}
 		await this.localCall(abi, [], options.sender)
-
 	}
 
 	public owner_ = async(options?: { sender?: string }): Promise<string> => {
@@ -1231,7 +1202,7 @@ export class Pausable<TBigNumber> extends Contract<TBigNumber> {
 	public transferOwnership = async(newOwner: string, options?: { sender?: string, gasPrice?: TBigNumber }): Promise<void> => {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[{"name":"newOwner","type":"address"}],"name":"transferOwnership","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"}
-		await this.remoteCall(abi, [newOwner], "transferOwnership", options.sender, options.gasPrice)
+		await this.remoteCall(abi, [newOwner], 'transferOwnership', options.sender, options.gasPrice)
 		return
 	}
 
@@ -1239,7 +1210,6 @@ export class Pausable<TBigNumber> extends Contract<TBigNumber> {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[{"name":"newOwner","type":"address"}],"name":"transferOwnership","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"}
 		await this.localCall(abi, [newOwner], options.sender)
-
 	}
 }
 
@@ -1252,7 +1222,7 @@ export class Peth<TBigNumber> extends Contract<TBigNumber> {
 	public approve = async(spender: string, value: TBigNumber, options?: { sender?: string, gasPrice?: TBigNumber }): Promise<void> => {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[{"name":"spender","type":"address"},{"name":"value","type":"uint256"}],"name":"approve","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"}
-		await this.remoteCall(abi, [spender, value], "approve", options.sender, options.gasPrice)
+		await this.remoteCall(abi, [spender, value], 'approve', options.sender, options.gasPrice)
 		return
 	}
 
@@ -1273,7 +1243,7 @@ export class Peth<TBigNumber> extends Contract<TBigNumber> {
 	public transferFrom = async(from: string, to: string, value: TBigNumber, options?: { sender?: string, gasPrice?: TBigNumber }): Promise<void> => {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[{"name":"from","type":"address"},{"name":"to","type":"address"},{"name":"value","type":"uint256"}],"name":"transferFrom","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"}
-		await this.remoteCall(abi, [from, to, value], "transferFrom", options.sender, options.gasPrice)
+		await this.remoteCall(abi, [from, to, value], 'transferFrom', options.sender, options.gasPrice)
 		return
 	}
 
@@ -1294,7 +1264,7 @@ export class Peth<TBigNumber> extends Contract<TBigNumber> {
 	public transfer = async(to: string, value: TBigNumber, options?: { sender?: string, gasPrice?: TBigNumber }): Promise<void> => {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[{"name":"to","type":"address"},{"name":"value","type":"uint256"}],"name":"transfer","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"}
-		await this.remoteCall(abi, [to, value], "transfer", options.sender, options.gasPrice)
+		await this.remoteCall(abi, [to, value], 'transfer', options.sender, options.gasPrice)
 		return
 	}
 
@@ -1329,7 +1299,7 @@ export class PullPayment<TBigNumber> extends Contract<TBigNumber> {
 	public withdrawPayments = async(options?: { sender?: string, gasPrice?: TBigNumber }): Promise<void> => {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[],"name":"withdrawPayments","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"}
-		await this.remoteCall(abi, [], "withdrawPayments", options.sender, options.gasPrice)
+		await this.remoteCall(abi, [], 'withdrawPayments', options.sender, options.gasPrice)
 		return
 	}
 
@@ -1337,7 +1307,6 @@ export class PullPayment<TBigNumber> extends Contract<TBigNumber> {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[],"name":"withdrawPayments","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"}
 		await this.localCall(abi, [], options.sender)
-
 	}
 
 	public payments_ = async(arg0: string, options?: { sender?: string }): Promise<TBigNumber> => {
@@ -1357,7 +1326,7 @@ export class Weth<TBigNumber> extends Contract<TBigNumber> {
 	public approve = async(spender: string, value: TBigNumber, options?: { sender?: string, gasPrice?: TBigNumber }): Promise<void> => {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[{"name":"spender","type":"address"},{"name":"value","type":"uint256"}],"name":"approve","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"}
-		await this.remoteCall(abi, [spender, value], "approve", options.sender, options.gasPrice)
+		await this.remoteCall(abi, [spender, value], 'approve', options.sender, options.gasPrice)
 		return
 	}
 
@@ -1378,7 +1347,7 @@ export class Weth<TBigNumber> extends Contract<TBigNumber> {
 	public transferFrom = async(from: string, to: string, value: TBigNumber, options?: { sender?: string, gasPrice?: TBigNumber }): Promise<void> => {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[{"name":"from","type":"address"},{"name":"to","type":"address"},{"name":"value","type":"uint256"}],"name":"transferFrom","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"}
-		await this.remoteCall(abi, [from, to, value], "transferFrom", options.sender, options.gasPrice)
+		await this.remoteCall(abi, [from, to, value], 'transferFrom', options.sender, options.gasPrice)
 		return
 	}
 
@@ -1392,7 +1361,7 @@ export class Weth<TBigNumber> extends Contract<TBigNumber> {
 	public withdraw = async(wad: TBigNumber, options?: { sender?: string, gasPrice?: TBigNumber }): Promise<void> => {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[{"name":"wad","type":"uint256"}],"name":"withdraw","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"}
-		await this.remoteCall(abi, [wad], "withdraw", options.sender, options.gasPrice)
+		await this.remoteCall(abi, [wad], 'withdraw', options.sender, options.gasPrice)
 		return
 	}
 
@@ -1400,7 +1369,6 @@ export class Weth<TBigNumber> extends Contract<TBigNumber> {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[{"name":"wad","type":"uint256"}],"name":"withdraw","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"}
 		await this.localCall(abi, [wad], options.sender)
-
 	}
 
 	public balanceOf_ = async(who: string, options?: { sender?: string }): Promise<TBigNumber> => {
@@ -1413,7 +1381,7 @@ export class Weth<TBigNumber> extends Contract<TBigNumber> {
 	public transfer = async(to: string, value: TBigNumber, options?: { sender?: string, gasPrice?: TBigNumber }): Promise<void> => {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[{"name":"to","type":"address"},{"name":"value","type":"uint256"}],"name":"transfer","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"}
-		await this.remoteCall(abi, [to, value], "transfer", options.sender, options.gasPrice)
+		await this.remoteCall(abi, [to, value], 'transfer', options.sender, options.gasPrice)
 		return
 	}
 
@@ -1427,7 +1395,7 @@ export class Weth<TBigNumber> extends Contract<TBigNumber> {
 	public deposit = async(options?: { sender?: string, gasPrice?: TBigNumber, attachedEth?: TBigNumber }): Promise<void> => {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[],"name":"deposit","outputs":[],"payable":true,"stateMutability":"payable","type":"function"}
-		await this.remoteCall(abi, [], "deposit", options.sender, options.gasPrice, options.attachedEth)
+		await this.remoteCall(abi, [], 'deposit', options.sender, options.gasPrice, options.attachedEth)
 		return
 	}
 
@@ -1435,7 +1403,6 @@ export class Weth<TBigNumber> extends Contract<TBigNumber> {
 		options = options || {}
 		const abi: AbiFunction = {"constant":false,"inputs":[],"name":"deposit","outputs":[],"payable":true,"stateMutability":"payable","type":"function"}
 		await this.localCall(abi, [], options.sender, options.attachedEth)
-
 	}
 
 	public allowance_ = async(owner: string, spender: string, options?: { sender?: string }): Promise<TBigNumber> => {

--- a/contracts/deployment/scripts/compile.ts
+++ b/contracts/deployment/scripts/compile.ts
@@ -21,14 +21,15 @@ async function doStuff() {
 
 async function writeJson(abi: (AbiFunction | AbiEvent)[]) {
 	const filePath = path.join(__dirname, '../../output/liquid-long-abi.json')
-	const data = JSON.stringify(abi, undefined, '\t')
-	return await fsWriteFile(filePath, data, { encoding: 'utf8', flag: 'w' })
+	const fileContents = JSON.stringify(abi, undefined, '\t')
+	return await fsWriteFile(filePath, fileContents, { encoding: 'utf8', flag: 'w' })
 }
 
 async function writeTs(compilerOutput: CompilerOutput) {
 	const filePath = path.join(__dirname, '../../output/liquid-long.ts')
-	await new ContractInterfaceGenerator().generateContractInterfaces(compilerOutput, filePath)
-	await fsCopyFile(filePath, path.join(__dirname, '../../../client-library/source/generated/liquid-long.ts'))
+	const fileContents = await new ContractInterfaceGenerator().generateContractInterfaces(compilerOutput)
+	await fsWriteFile(filePath, fileContents, { encoding: 'utf8', flag: 'w' })
+	await fsWriteFile(path.join(__dirname, '../../../client-library/library/source/generated/liquid-long.ts'), fileContents, { encoding: 'utf8', flag: 'w' })
 }
 
 doStuff().then(() => {

--- a/contracts/deployment/tsconfig.json
+++ b/contracts/deployment/tsconfig.json
@@ -7,5 +7,6 @@
 		"noEmit": true,
 		"strict": true,
 		"lib": [ "es2018", ],
+		"typeRoots": [ "./typings", "../node_modules/@types" ],
 	}
 }

--- a/contracts/deployment/typings/ethereum/index.d.ts
+++ b/contracts/deployment/typings/ethereum/index.d.ts
@@ -1,0 +1,32 @@
+declare module 'ethereum' {
+	export type Primitive = 'uint8' | 'uint64' | 'uint256' | 'bool' | 'string' | 'address' | 'bytes20' | 'bytes32' | 'bytes' | 'int256' | 'tuple' | 'address[]' | 'uint256[]' | 'bytes32[]' | 'tuple[]';
+
+	export interface AbiParameter {
+		name: string,
+		type: Primitive,
+		components?: Array<AbiParameter>
+	}
+
+	export interface AbiEventParameter extends AbiParameter {
+		indexed: boolean,
+	}
+
+	export interface AbiFunction {
+		name: string,
+		type: 'function' | 'constructor' | 'fallback',
+		stateMutability: 'pure' | 'view' | 'payable' | 'nonpayable',
+		constant: boolean,
+		payable: boolean,
+		inputs: Array<AbiParameter>,
+		outputs: Array<AbiParameter>,
+	}
+
+	export interface AbiEvent {
+		name: string,
+		type: 'event',
+		inputs: Array<AbiEventParameter>,
+		anonymous: boolean,
+	}
+
+	export type Abi = Array<AbiFunction | AbiEvent>;
+}

--- a/contracts/deployment/typings/recursive-readdir/index.d.ts
+++ b/contracts/deployment/typings/recursive-readdir/index.d.ts
@@ -1,0 +1,15 @@
+declare module 'recursive-readdir' {
+	import * as fs from "fs";
+	namespace RecursiveReaddir {
+		type IgnoreFunction = (file: string, stats: fs.Stats) => boolean;
+		type Callback = (error: Error, files: string[]) => void;
+		interface readDir {
+			(path: string, ignores?: (string|IgnoreFunction)[]): Promise<string[]>;
+			(path: string, callback: Callback): void;
+			(path: string, ignores: (string|IgnoreFunction)[], callback: Callback): void;
+		}
+	}
+
+	var recursiveReadDir: RecursiveReaddir.readDir;
+	export = recursiveReadDir;
+}

--- a/contracts/deployment/typings/solc/index.d.ts
+++ b/contracts/deployment/typings/solc/index.d.ts
@@ -1,37 +1,3 @@
-
-declare module 'ethereum' {
-	export type Primitive = 'uint8' | 'uint64' | 'uint256' | 'bool' | 'string' | 'address' | 'bytes20' | 'bytes32' | 'bytes' | 'int256' | 'tuple' | 'address[]' | 'uint256[]' | 'bytes32[]' | 'tuple[]';
-
-	export interface AbiParameter {
-		name: string,
-		type: Primitive,
-		components?: Array<AbiParameter>
-	}
-
-	export interface AbiEventParameter extends AbiParameter {
-		indexed: boolean,
-	}
-
-	export interface AbiFunction {
-		name: string,
-		type: 'function' | 'constructor' | 'fallback',
-		stateMutability: 'pure' | 'view' | 'payable' | 'nonpayable',
-		constant: boolean,
-		payable: boolean,
-		inputs: Array<AbiParameter>,
-		outputs: Array<AbiParameter>,
-	}
-
-	export interface AbiEvent {
-		name: string,
-		type: 'event',
-		inputs: Array<AbiEventParameter>,
-		anonymous: boolean,
-	}
-
-	export type Abi = Array<AbiFunction | AbiEvent>;
-}
-
 declare module 'solc' {
 	import { Abi, Primitive } from 'ethereum';
 
@@ -123,20 +89,4 @@ declare module 'solc' {
 	}
 	type ReadCallback = (path: string) => { contents?: string, error?: string};
 	function compileStandardWrapper(input: string, readCallback?: ReadCallback): string;
-}
-
-declare module 'recursive-readdir' {
-	import * as fs from "fs";
-	namespace RecursiveReaddir {
-		type IgnoreFunction = (file: string, stats: fs.Stats) => boolean;
-		type Callback = (error: Error, files: string[]) => void;
-		interface readDir {
-			(path: string, ignores?: (string|IgnoreFunction)[]): Promise<string[]>;
-			(path: string, callback: Callback): void;
-			(path: string, ignores: (string|IgnoreFunction)[], callback: Callback): void;
-		}
-	}
-
-	var recursiveReadDir: RecursiveReaddir.readDir;
-	export = recursiveReadDir;
 }

--- a/contracts/package-lock.json
+++ b/contracts/package-lock.json
@@ -38,15 +38,6 @@
 			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
 			"dev": true
 		},
-		"ansi-styles": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-			"dev": true,
-			"requires": {
-				"color-convert": "1.9.2"
-			}
-		},
 		"arrify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
@@ -82,9 +73,9 @@
 			"dev": true
 		},
 		"buffer-from": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.0.tgz",
-			"integrity": "sha512-c5mRlguI/Pe2dSZmpER62rSCu0ryKmWddzRYsuXc50U2/g8jMOulc31VZMa4mYx31U5xsmSOpDCgH88Vl9cDGQ==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
 			"dev": true
 		},
 		"builtin-modules": {
@@ -98,17 +89,6 @@
 			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
 			"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
 			"dev": true
-		},
-		"chalk": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-			"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-			"dev": true,
-			"requires": {
-				"ansi-styles": "3.2.1",
-				"escape-string-regexp": "1.0.5",
-				"supports-color": "5.4.0"
-			}
 		},
 		"cliui": {
 			"version": "3.2.0",
@@ -125,21 +105,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
 			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-			"dev": true
-		},
-		"color-convert": {
-			"version": "1.9.2",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.2.tgz",
-			"integrity": "sha512-3NUJZdhMhcdPn8vJ9v2UQJoH0qqoGUkYTgFEPZaPjEtwmmKUfNV46zZmgB2M5M4DCEQHMaCfWHCxiBflLm04Tg==",
-			"dev": true,
-			"requires": {
-				"color-name": "1.1.1"
-			}
-		},
-		"color-name": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
-			"integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok=",
 			"dev": true
 		},
 		"concat-map": {
@@ -180,12 +145,6 @@
 			"requires": {
 				"is-arrayish": "0.2.1"
 			}
-		},
-		"escape-string-regexp": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-			"dev": true
 		},
 		"ethers": {
 			"version": "4.0.3",
@@ -252,15 +211,15 @@
 			"dev": true
 		},
 		"get-caller-file": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-			"integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+			"integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
 			"dev": true
 		},
 		"glob": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+			"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
 			"dev": true,
 			"requires": {
 				"fs.realpath": "1.0.0",
@@ -277,12 +236,6 @@
 			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
 			"dev": true
 		},
-		"has-flag": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-			"dev": true
-		},
 		"hash.js": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
@@ -294,9 +247,9 @@
 			}
 		},
 		"hosted-git-info": {
-			"version": "2.6.1",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.1.tgz",
-			"integrity": "sha512-Ba4+0M4YvIDUUsprMjhVTU1yN9F2/LJSAl69ZpzaLT4l4j5mwTS6jqqW9Ojvj6lKz/veqPzpJBqGbXspOb533A==",
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
+			"integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
 			"dev": true
 		},
 		"inflight": {
@@ -329,7 +282,7 @@
 		},
 		"is-builtin-module": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+			"resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
 			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
 			"dev": true,
 			"requires": {
@@ -359,7 +312,7 @@
 		},
 		"jsonfile": {
 			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+			"resolved": "http://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
 			"integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
 			"dev": true,
 			"requires": {
@@ -386,7 +339,7 @@
 		},
 		"load-json-file": {
 			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+			"resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
 			"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
 			"dev": true,
 			"requires": {
@@ -404,9 +357,9 @@
 			"dev": true
 		},
 		"make-error": {
-			"version": "1.3.4",
-			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.4.tgz",
-			"integrity": "sha512-0Dab5btKVPhibSalc9QGXb559ED7G7iLjFXBaj9Wq8O3vorueR5K5jaE3hkG6ZQINyhA/JgG6Qk4qdFQjsYV6g==",
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
+			"integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==",
 			"dev": true
 		},
 		"memorystream": {
@@ -465,10 +418,10 @@
 			"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
 			"dev": true,
 			"requires": {
-				"hosted-git-info": "2.6.1",
+				"hosted-git-info": "2.7.1",
 				"is-builtin-module": "1.0.0",
-				"semver": "5.5.0",
-				"validate-npm-package-license": "3.0.3"
+				"semver": "5.5.1",
+				"validate-npm-package-license": "3.0.4"
 			}
 		},
 		"number-is-nan": {
@@ -488,7 +441,7 @@
 		},
 		"os-locale": {
 			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+			"resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
 			"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
 			"dev": true,
 			"requires": {
@@ -605,7 +558,7 @@
 			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
 			"dev": true,
 			"requires": {
-				"glob": "7.1.2"
+				"glob": "7.1.3"
 			}
 		},
 		"scrypt-js": {
@@ -615,9 +568,9 @@
 			"dev": true
 		},
 		"semver": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-			"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+			"version": "5.5.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
+			"integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw==",
 			"dev": true
 		},
 		"set-blocking": {
@@ -633,15 +586,15 @@
 			"dev": true
 		},
 		"solc": {
-			"version": "0.4.24",
-			"resolved": "https://registry.npmjs.org/solc/-/solc-0.4.24.tgz",
-			"integrity": "sha512-2xd7Cf1HeVwrIb6Bu1cwY2/TaLRodrppCq3l7rhLimFQgmxptXhTC3+/wesVLpB09F1A2kZgvbMOgH7wvhFnBQ==",
+			"version": "0.4.25",
+			"resolved": "https://registry.npmjs.org/solc/-/solc-0.4.25.tgz",
+			"integrity": "sha512-jU1YygRVy6zatgXrLY2rRm7HW1d7a8CkkEgNJwvH2VLpWhMFsMdWcJn6kUqZwcSz/Vm+w89dy7Z/aB5p6AFTrg==",
 			"dev": true,
 			"requires": {
 				"fs-extra": "0.30.0",
 				"memorystream": "0.3.1",
 				"require-from-string": "1.2.1",
-				"semver": "5.5.0",
+				"semver": "5.5.1",
 				"yargs": "4.8.1"
 			}
 		},
@@ -652,29 +605,29 @@
 			"dev": true
 		},
 		"source-map-support": {
-			"version": "0.5.6",
-			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.6.tgz",
-			"integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
+			"version": "0.5.9",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
+			"integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
 			"dev": true,
 			"requires": {
-				"buffer-from": "1.1.0",
+				"buffer-from": "1.1.1",
 				"source-map": "0.6.1"
 			}
 		},
 		"spdx-correct": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
-			"integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.2.tgz",
+			"integrity": "sha512-q9hedtzyXHr5S0A1vEPoK/7l8NpfkFYTq6iCY+Pno2ZbdZR6WexZFtqeVGkGxW3TEJMN914Z55EnAGMmenlIQQ==",
 			"dev": true,
 			"requires": {
 				"spdx-expression-parse": "3.0.0",
-				"spdx-license-ids": "3.0.0"
+				"spdx-license-ids": "3.0.1"
 			}
 		},
 		"spdx-exceptions": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
-			"integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+			"integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
 			"dev": true
 		},
 		"spdx-expression-parse": {
@@ -683,14 +636,14 @@
 			"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
 			"dev": true,
 			"requires": {
-				"spdx-exceptions": "2.1.0",
-				"spdx-license-ids": "3.0.0"
+				"spdx-exceptions": "2.2.0",
+				"spdx-license-ids": "3.0.1"
 			}
 		},
 		"spdx-license-ids": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
-			"integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.1.tgz",
+			"integrity": "sha512-TfOfPcYGBB5sDuPn3deByxPhmfegAhpDYKSOXZQN81Oyrrif8ZCodOLzK3AesELnCx03kikhyDwh0pfvvQvF8w==",
 			"dev": true
 		},
 		"string-width": {
@@ -706,7 +659,7 @@
 		},
 		"strip-ansi": {
 			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+			"resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 			"dev": true,
 			"requires": {
@@ -722,50 +675,41 @@
 				"is-utf8": "0.2.1"
 			}
 		},
-		"supports-color": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-			"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-			"dev": true,
-			"requires": {
-				"has-flag": "3.0.0"
-			}
-		},
 		"ts-node": {
-			"version": "6.0.5",
-			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-6.0.5.tgz",
-			"integrity": "sha512-iNhWu2hli9/1p9PGLJ/4OZS+NR0IVEVk63KCrH3qa7jJZxXa+oPheBj5JyM8tuQM9RkBpw1PrNUEUPJR9wTGDw==",
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-7.0.1.tgz",
+			"integrity": "sha512-BVwVbPJRspzNh2yfslyT1PSbl5uIk03EZlb493RKHN4qej/D06n1cEhjlOJG69oFsE7OT8XjpTUcYf6pKTLMhw==",
 			"dev": true,
 			"requires": {
 				"arrify": "1.0.1",
-				"chalk": "2.4.1",
+				"buffer-from": "1.1.1",
 				"diff": "3.5.0",
-				"make-error": "1.3.4",
+				"make-error": "1.3.5",
 				"minimist": "1.2.0",
 				"mkdirp": "0.5.1",
-				"source-map-support": "0.5.6",
+				"source-map-support": "0.5.9",
 				"yn": "2.0.0"
 			}
 		},
 		"typescript": {
-			"version": "2.8.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-2.8.3.tgz",
-			"integrity": "sha512-K7g15Bb6Ra4lKf7Iq2l/I5/En+hLIHmxWZGq3D4DIRNFxMNV6j2SHSvDOqs2tGd4UvD/fJvrwopzQXjLrT7Itw==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.1.tgz",
+			"integrity": "sha512-Veu0w4dTc/9wlWNf2jeRInNodKlcdLgemvPsrNpfu5Pq39sgfFjvIIgTsvUHCoLBnMhPoUA+tFxsXjU6VexVRQ==",
 			"dev": true
 		},
 		"uuid": {
 			"version": "2.0.1",
-			"resolved": "http://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
 			"integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w=",
 			"dev": true
 		},
 		"validate-npm-package-license": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
-			"integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+			"integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
 			"dev": true,
 			"requires": {
-				"spdx-correct": "3.0.0",
+				"spdx-correct": "3.0.2",
 				"spdx-expression-parse": "3.0.0"
 			}
 		},
@@ -783,7 +727,7 @@
 		},
 		"wrap-ansi": {
 			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+			"resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
 			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
 			"dev": true,
 			"requires": {
@@ -811,13 +755,13 @@
 		},
 		"yargs": {
 			"version": "4.8.1",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
+			"resolved": "http://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
 			"integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
 			"dev": true,
 			"requires": {
 				"cliui": "3.2.0",
 				"decamelize": "1.2.0",
-				"get-caller-file": "1.0.2",
+				"get-caller-file": "1.0.3",
 				"lodash.assign": "4.2.0",
 				"os-locale": "1.4.0",
 				"read-pkg-up": "1.0.1",
@@ -833,7 +777,7 @@
 		},
 		"yargs-parser": {
 			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
+			"resolved": "http://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
 			"integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
 			"dev": true,
 			"requires": {

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -10,8 +10,8 @@
 		"fs-readfile-promise": "3.0.1",
 		"node-fetch": "2.1.2",
 		"recursive-readdir": "2.2.2",
-		"solc": "0.4.24",
-		"ts-node": "6.0.5",
-		"typescript": "2.8.3"
+		"solc": "0.4.25",
+		"ts-node": "7.0.1",
+		"typescript": "3.1.1"
 	}
 }

--- a/contracts/source/liquid-long.sol
+++ b/contracts/source/liquid-long.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity 0.4.25;
 pragma experimental ABIEncoderV2;
 pragma experimental "v0.5.0";
 

--- a/contracts/test-tools/libraries/ContractInterfaces.ts
+++ b/contracts/test-tools/libraries/ContractInterfaces.ts
@@ -17,8 +17,6 @@ type EthersOptions = {
   value?: BigNumber;
 }
 
-const TRANSACTION_TIMEOUT = 120000;
-
 class CallableContract {
 	private readonly gasPrice: BigNumber;
 	private readonly contract: Contract;
@@ -41,12 +39,12 @@ class CallableContract {
 		if (attachedEth !== undefined) overrideOptions["value"] = bigNumberify(attachedEth);
 		const txDetails = await this.contract.functions[txName](...parameters, overrideOptions);
 		const hash = txDetails.hash;
-		await this.contract.provider.waitForTransaction(hash, TRANSACTION_TIMEOUT);
+		await this.contract.provider.waitForTransaction(hash);
 		const txReceipt = await this.contract.provider.getTransactionReceipt(hash);
 		if (txReceipt.blockNumber! >= 0) {
 			return hash;
 		} else {
-			throw new Error(`Transaction ${hash} submitted, but not mined within ${TRANSACTION_TIMEOUT}ms`);
+			throw new Error(`Transaction ${hash} submitted, but not mined`);
 		}
 	}
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
                 - ETHEREUM_OASIS_ADDRESS=0x3c6721551c2ba3973560aef3e11d34ce05db4047
                 - ETHEREUM_MAKER_ADRESS=0x93943fb2d02ce1101dadc3ab1bc3cab723fd19d6
         ports:
-            - "14993:8545"
+            - "1235:8545"
 
     geth:
         build:
@@ -23,6 +23,8 @@ services:
                 - ETHEREUM_PRIVATE_KEY=fae42052f82bed612a724fec3632f325f377120592c75bb78adfcceae6470c5a
                 - ETHEREUM_OASIS_ADDRESS=0x3c6721551c2ba3973560aef3e11d34ce05db4047
                 - ETHEREUM_MAKER_ADRESS=0x93943fb2d02ce1101dadc3ab1bc3cab723fd19d6
+        ports:
+            - "1236:8545"
 
     client-library-parity:
         build: ./client-library


### PR DESCRIPTION
`ContractInterfaceGenerator` no longer has any dependencies.  This will make it easy to extract into a separate project.

Bumped dependency versions.  Primarily wanted to get TypeScript 3, but brought in solc 0.4.25 as well since it was easy and "just worked".  This had the side effect of needing to change how global modules got picked up due to a change in `ts-node`.

Fixes a bug in `placeOrder` caused by a change in `ethers.js` API where a parameter that previously meant `timout` now meant `number_of_confirmations`.