### PR TITLE
Adds script for depositing ETH into contracts.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -53,9 +53,9 @@
 			"name": "Oasis Orders - Parity",
 			"cwd": "${workspaceFolder}/contracts",
 			"runtimeArgs": [ "-r", "ts-node/register", ],
-			"args": [ "${workspaceFolder}/contracts/test-tools/scripts/placeOrder.ts", ],
+			"args": [ "${workspaceFolder}/toolbox/scripts/seed-oasis.ts", ],
 			"env": {
-				"TS_NODE_PROJECT": "${workspaceFolder}/contracts/test-tools/tsconfig.json",
+				"TS_NODE_PROJECT": "${workspaceFolder}/toolbox/tsconfig.json",
 				"ETHEREUM_HTTP": "http://localhost:1235",
 				"ETHEREUM_GAS_PRICE_IN_NANOETH": "1",
 				"ETHEREUM_PRIVATE_KEY": "fae42052f82bed612a724fec3632f325f377120592c75bb78adfcceae6470c5a",
@@ -69,9 +69,9 @@
 			"name": "Oasis Orders - Geth",
 			"cwd": "${workspaceFolder}/contracts",
 			"runtimeArgs": [ "-r", "ts-node/register", ],
-			"args": [ "${workspaceFolder}/contracts/test-tools/scripts/placeOrder.ts", ],
+			"args": [ "${workspaceFolder}/toolbox/scripts/seed-oasis.ts", ],
 			"env": {
-				"TS_NODE_PROJECT": "${workspaceFolder}/contracts/test-tools/tsconfig.json",
+				"TS_NODE_PROJECT": "${workspaceFolder}/toolbox/tsconfig.json",
 				"ETHEREUM_HTTP": "http://localhost:1236",
 				"ETHEREUM_GAS_PRICE_IN_NANOETH": "1",
 				"ETHEREUM_PRIVATE_KEY": "fae42052f82bed612a724fec3632f325f377120592c75bb78adfcceae6470c5a",
@@ -82,12 +82,27 @@
 		{
 			"type": "node",
 			"request": "launch",
+			"name": "Deposit ETH - Parity",
+			"cwd": "${workspaceFolder}/contracts",
+			"runtimeArgs": [ "-r", "ts-node/register", ],
+			"args": [ "${workspaceFolder}/toolbox/scripts/deposit-eth.ts", ],
+			"env": {
+				"TS_NODE_PROJECT": "${workspaceFolder}/toolbox/tsconfig.json",
+				"ETHEREUM_HTTP": "http://localhost:1235",
+				"ETHEREUM_GAS_PRICE_IN_NANOETH": "1",
+				"ETHEREUM_PRIVATE_KEY": "fae42052f82bed612a724fec3632f325f377120592c75bb78adfcceae6470c5a",
+				"ETHEREUM_LIQUID_LONG_ADDRESS": "0x80F8DAA435A9AB4B1802BA56FE7E0ABD0F8AB3D3",
+			}
+		},
+		{
+			"type": "node",
+			"request": "launch",
 			"name": "Sandbox",
 			"cwd": "${workspaceFolder}/contracts",
 			"runtimeArgs": [ "-r", "ts-node/register", ],
-			"args": [ "${workspaceFolder}/contracts/test-tools/scripts/sandbox.ts", ],
+			"args": [ "${workspaceFolder}/toolbox/scripts/sandbox.ts", ],
 			"env": {
-				"TS_NODE_PROJECT": "${workspaceFolder}/contracts/test-tools/tsconfig.json",
+				"TS_NODE_PROJECT": "${workspaceFolder}/toolbox/tsconfig.json",
 			}
 		},
 		{
@@ -98,6 +113,19 @@
 			"program": "${workspaceFolder}/client-library/tests/node_modules/mocha/bin/_mocha",
 			"args": [ "--require", "ts-node/register", "--timeout", "999999", "--colors", "source/**/*.ts" ],
 			"preLaunchTask": "build client library",
+		},
+		{
+			"type": "node",
+			"request": "launch",
+			"name": "Client Library Integration Tests",
+			"cwd": "${workspaceFolder}/client-library/integration-tests/",
+			"program": "${workspaceFolder}/client-library/integration-tests/node_modules/mocha/bin/_mocha",
+			"args": [ "--require", "ts-node/register", "--timeout", "999999", "--colors", "source/**/*.ts" ],
+			"env": {
+				"TS_NODE_PROJECT": "${workspaceFolder}/client-library/integration-tests/tsconfig.json",
+				"ETHEREUM_HTTP": "http://localhost:1235",
+				"ETHEREUM_LIQUID_LONG_ADDRESS": "0x80F8DAA435A9AB4B1802BA56FE7E0ABD0F8AB3D3",
+			}
 		}
 	]
 }

--- a/client-library/library/source/index.ts
+++ b/client-library/library/source/index.ts
@@ -1,6 +1,6 @@
 export { LiquidLong } from './liquid-long'
 export { Scheduler, TimeoutScheduler } from './scheduler'
 export { PolledValue } from './polled-value'
-export { Provider } from './liquid-long-ethers-impl'
+export { Provider, Signer } from './liquid-long-ethers-impl'
 export { BigNumber, bigNumberify } from 'ethers/utils'
 export { JsonRpcProvider, TransactionResponse, TransactionRequest, TransactionReceipt } from 'ethers/providers';

--- a/client-library/tests/source/liquid-long-tests.ts
+++ b/client-library/tests/source/liquid-long-tests.ts
@@ -3,18 +3,21 @@ import { expect } from 'chai'
 import { LiquidLong } from '@keydonix/liquid-long-client-library'
 import { MockProvider } from './mock-provider'
 import { MockScheduler } from './mock-scheduler';
+import { MockSigner } from './mock-signer';
 
 const ZERO_ADRESS = '0x0000000000000000000000000000000000000000'
 
 describe('LiquidLong', async () => {
 	let mockScheduler: MockScheduler
 	let mockProvider: MockProvider
+	let mockSigner: MockSigner
 	let liquidLong: LiquidLong
 
 	beforeEach(async () => {
 		mockScheduler = new MockScheduler()
 		mockProvider = new MockProvider()
-		liquidLong = new LiquidLong(mockScheduler, mockProvider, ZERO_ADRESS, 1, 0.01)
+		mockSigner = new MockSigner()
+		liquidLong = new LiquidLong(mockScheduler, mockProvider, mockSigner, ZERO_ADRESS, 1, 0.01)
 	})
 
 	afterEach(async () => {

--- a/client-library/tests/source/mock-provider.ts
+++ b/client-library/tests/source/mock-provider.ts
@@ -30,12 +30,6 @@ export class MockProvider implements Provider {
 	async listAccounts(): Promise<string[]> {
 		return this.accounts
 	}
-	async send(method: string, params: any): Promise<any> {
-		throw new Error("Method not implemented.")
-	}
-	async sendTransaction(signedTransaction: string | Promise<string>): Promise<TransactionResponse> {
-		throw new Error("Method not implemented.")
-	}
 	async call(transaction: TransactionRequest): Promise<string> {
 		// getEthPrice()
 		if (transaction.data === '0x683e0bcd') return defaultAbiCoder.encode(['uint256'], [this.ethPriceInAttousd])
@@ -44,12 +38,6 @@ export class MockProvider implements Provider {
 		// TODO: make this decode the inputs and compute a reasonable output
 		// estimateDaiSaleProceeds(uint256)
 		if (typeof transaction.data === 'string' && transaction.data.startsWith('0x5988899c')) return defaultAbiCoder.encode(['uint256', 'uint256'], [this.attodaiPaidCost, this.attoethBoughtCost])
-		throw new Error("Method not implemented.")
-	}
-	async estimateGas(transaction: TransactionRequest): Promise<BigNumber> {
-		throw new Error("Method not implemented.")
-	}
-	async getTransactionReceipt(transactionHash: string): Promise<TransactionReceipt> {
 		throw new Error("Method not implemented.")
 	}
 }

--- a/client-library/tests/source/mock-signer.ts
+++ b/client-library/tests/source/mock-signer.ts
@@ -1,0 +1,7 @@
+import { Signer, TransactionRequest, TransactionResponse } from '@keydonix/liquid-long-client-library'
+
+export class MockSigner implements Signer {
+	sendTransaction(transaction: TransactionRequest): Promise<TransactionResponse> {
+		throw new Error("Method not implemented.");
+	}
+}

--- a/contracts/deployment/scripts/compile.ts
+++ b/contracts/deployment/scripts/compile.ts
@@ -6,17 +6,13 @@ import * as path from 'path'
 import { promisify } from 'util'
 import { CompilerOutput } from 'solc';
 const fsWriteFile = promisify(fs.writeFile)
-const fsCopyFile = promisify(fs.copyFile)
 
 async function doStuff() {
 	const contractCompiler = new ContractCompiler()
 	const compilerOutput = await contractCompiler.compileContracts()
 	const abi = compilerOutput.contracts['liquid-long.sol']['LiquidLong'].abi
-	const bytecode = compilerOutput.contracts['liquid-long.sol']['LiquidLong'].evm.bytecode.object
 	await writeJson(abi)
 	await writeTs(compilerOutput)
-	console.log(JSON.stringify(abi))
-	console.log(bytecode)
 }
 
 async function writeJson(abi: (AbiFunction | AbiEvent)[]) {

--- a/contracts/source/liquid-long.sol
+++ b/contracts/source/liquid-long.sol
@@ -360,10 +360,10 @@ contract LiquidLong is Ownable, Claimable, Pausable, PullPayment, CdpHolder {
 
 	Oasis public oasis;
 	Maker public maker;
-	Dai private dai;
-	Weth private weth;
-	Peth private peth;
-	Mkr private mkr;
+	Dai public dai;
+	Weth public weth;
+	Peth public peth;
+	Mkr public mkr;
 
 	event NewCup(address user, bytes32 cup);
 
@@ -548,7 +548,7 @@ contract LiquidLong is Ownable, Claimable, Pausable, PullPayment, CdpHolder {
 		uint256 _providerFeeInAttoeth = mul18(_loanInAttoeth, providerFeePerEth);
 		require(_providerFeeInAttoeth <= _allowedFeeInAttoeth);
 		uint256 _drawInAttodai = mul18(_loanInAttoeth, uint256(maker.pip().read()));
-		uint256 _pethLockedInCdp = div27(_lockedInCdpInAttoeth, maker.per()) ;
+		uint256 _pethLockedInCdp = div27(_lockedInCdpInAttoeth, maker.per());
 
 		// Convert ETH to WETH (only the value amount, excludes loan amount which is already WETH)
 		weth.deposit.value(_leverageSizeInAttoeth)();

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
             - parity
         environment:
             - ETHEREUM_HTTP=http://parity:8545
-            - ETHEREUM_LIQUID_LONG_ADDRESS=80F8DAA435A9AB4B1802BA56FE7E0ABD0F8AB3D3
+            - ETHEREUM_LIQUID_LONG_ADDRESS=0x80F8DAA435A9AB4B1802BA56FE7E0ABD0F8AB3D3
 
     client-library-geth:
         build: ./client-library
@@ -40,4 +40,4 @@ services:
             - geth
         environment:
             - ETHEREUM_HTTP=http://geth:8545
-            - ETHEREUM_LIQUID_LONG_ADDRESS=80F8DAA435A9AB4B1802BA56FE7E0ABD0F8AB3D3
+            - ETHEREUM_LIQUID_LONG_ADDRESS=0x80F8DAA435A9AB4B1802BA56FE7E0ABD0F8AB3D3

--- a/toolbox/libraries/Environment.ts
+++ b/toolbox/libraries/Environment.ts
@@ -1,0 +1,6 @@
+export function getEnv(name: string, fallback?: string): string {
+	const value = process.env[name]
+	if (value !== undefined) return value
+	if (fallback === undefined) throw new Error(`${name} environment variable required`)
+	return fallback
+}

--- a/toolbox/libraries/liquid-long-ethers-impl.ts
+++ b/toolbox/libraries/liquid-long-ethers-impl.ts
@@ -1,0 +1,38 @@
+import { Dependencies, AbiFunction, AbiParameter, Transaction } from './liquid-long'
+import { keccak256, toUtf8Bytes, BigNumber, AbiCoder, bigNumberify } from 'ethers/utils'
+import { TransactionResponse, TransactionRequest, TransactionReceipt } from 'ethers/providers';
+import { Wallet } from 'ethers/wallet';
+
+export interface Provider {
+	listAccounts(): Promise<Array<string>>
+	send(method: string, params: any): Promise<any>
+	sendTransaction(signedTransaction: string | Promise<string>): Promise<TransactionResponse>
+	call(transaction: TransactionRequest): Promise<string>
+	estimateGas(transaction: TransactionRequest): Promise<BigNumber>
+	getTransactionReceipt(transactionHash: string): Promise<TransactionReceipt>
+	getTransactionCount(address: string): Promise<number>
+}
+
+export class LiquidLongDependenciesEthers implements Dependencies<BigNumber> {
+	private readonly provider: Provider
+	private readonly wallet: Wallet
+	private readonly gasPriceInNeth: number
+	public constructor(provider: Provider, wallet: Wallet, gasPriceInNeth: number) {
+		this.provider = provider
+		this.wallet = wallet
+		this.gasPriceInNeth = gasPriceInNeth
+	}
+
+	keccak256 = (utf8String: string) => keccak256(toUtf8Bytes(utf8String))
+	encodeParams = (abiFunction: AbiFunction, parameters: Array<any>) => new AbiCoder().encode(abiFunction.inputs, parameters).substr(2)
+	decodeParams = (abiParameters: Array<AbiParameter>, encoded: string) => new AbiCoder().decode(abiParameters, encoded)
+	getDefaultAddress = async () => (await this.provider.listAccounts())[0]
+	call = async (transaction: Transaction<BigNumber>) => await this.provider.call(transaction)
+	submitTransaction = async (transaction: Transaction<BigNumber>) => {
+		const gasEstimate = await this.provider.estimateGas(transaction)
+		Object.assign({}, transaction, { gasLimit: gasEstimate, gasPrice: bigNumberify(this.gasPriceInNeth).mul(1e9) })
+		const receipt = await (await this.wallet.sendTransaction(transaction)).wait()
+		if (receipt.status === undefined) throw new Error(`Receipt status was undefined, expected a number.\n${receipt}`)
+		return { status: receipt.status! }
+	}
+}

--- a/toolbox/scripts/deposit-eth.ts
+++ b/toolbox/scripts/deposit-eth.ts
@@ -1,0 +1,35 @@
+import { getEnv } from '../libraries/Environment'
+import { PrivateKey } from '../libraries/PrivateKey'
+import { LiquidLong, Weth } from '../libraries/liquid-long'
+import { LiquidLongDependenciesEthers } from '../libraries/liquid-long-ethers-impl'
+import { JsonRpcProvider } from 'ethers/providers'
+import { Wallet } from 'ethers/wallet'
+import { bigNumberify } from 'ethers/utils';
+
+async function doStuff() {
+	// gather/validate inputs
+	const jsonRpcAddress = getEnv('ETHEREUM_HTTP', 'http://localhost:1235')
+	const gasPrice = parseInt(getEnv('ETHEREUM_GAS_PRICE_IN_NANOETH', '1'), 10)
+	const liquidLongAddress = getEnv('ETHEREUM_LIQUID_LONG_ADDRESS', '0x80F8DAA435A9AB4B1802BA56FE7E0ABD0F8AB3D3')
+	const privateKey = PrivateKey.fromHexString(getEnv('ETHEREUM_PRIVATE_KEY', 'fae42052f82bed612a724fec3632f325f377120592c75bb78adfcceae6470c5a'))
+
+	const provider = new JsonRpcProvider(jsonRpcAddress, 4173)
+	const wallet = new Wallet(privateKey.toHexStringWithPrefix(), provider)
+
+	const dependencies = new LiquidLongDependenciesEthers(provider, wallet, gasPrice)
+	const liquidLong = new LiquidLong(dependencies, liquidLongAddress)
+	// FIXME: once new images are published, we can get wethAddress from `await liquidLong.weth_()`
+	const weth = new Weth(dependencies, '0xfcaf25bf38e7c86612a25ff18cb8e09ab07c9885')
+	console.log(`Depositing 100 ETH into Liquid Long.`)
+	await liquidLong.wethDeposit({ attachedEth: bigNumberify(100).mul(1e18.toString()) })
+	console.log(`Confirming new balance.`)
+	const newBalance = await weth.balanceOf_(liquidLongAddress)
+	console.log(`New weth balance: ${newBalance.div(1e9).toNumber() / 1e9}`)
+}
+
+doStuff().then(() => {
+	process.exit(0)
+}).catch(error => {
+	console.error(error)
+	process.exit(1)
+})

--- a/toolbox/scripts/sandbox.ts
+++ b/toolbox/scripts/sandbox.ts
@@ -2,6 +2,7 @@ import { Wallet } from 'ethers/wallet'
 import { JsonRpcProvider } from 'ethers/providers'
 import { bigNumberify, keccak256, toUtf8Bytes, AbiCoder } from 'ethers/utils'
 import { LiquidLong } from '../libraries/liquid-long'
+import { LiquidLongDependenciesEthers } from '../libraries/liquid-long-ethers-impl';
 
 const makerAbi = [
 	{
@@ -2548,21 +2549,8 @@ const oasisAbi = [
 async function doStuff() {
 	const provider = new JsonRpcProvider('http://localhost:1235', 4173)
 	const wallet = new Wallet('0xfae42052f82bed612a724fec3632f325f377120592c75bb78adfcceae6470c5a', provider)
-	const liquidLong = new LiquidLong({
-		keccak256: utf8String => keccak256(toUtf8Bytes(utf8String)),
-		encodeParams: (abiParameters, parameters) => new AbiCoder().encode(abiParameters.inputs, parameters).substr(2),
-		decodeParams: (abiParameters, encoded) => new AbiCoder().decode(abiParameters, encoded),
-		getDefaultAddress: async () => (await provider.listAccounts())[0],
-		call: async transaction => await provider.call(transaction),
-		estimateGas: async transaction => await provider.estimateGas(transaction),
-		signTransaction: async transaction => await wallet.sign(transaction),
-		sendSignedTransaction: async signedTransaction => {
-			const transactionResponse = await provider.sendTransaction(signedTransaction)
-			await transactionResponse.wait()
-			const transactionReceipt = await provider.getTransactionReceipt(transactionResponse.hash!)
-			return { status: transactionReceipt.status! }
-		},
-	}, '0x80F8DAA435A9AB4B1802BA56FE7E0ABD0F8AB3D3', bigNumberify(1000000000))
+	const dependencies = new LiquidLongDependenciesEthers(provider, wallet, 1)
+	const liquidLong = new LiquidLong(dependencies, '0x80F8DAA435A9AB4B1802BA56FE7E0ABD0F8AB3D3')
 	// const maker = new Contract('0x93943fb2d02ce1101dadc3ab1bc3cab723fd19d6', makerAbi, wallet)
 	// const oasis = new Contract('0x3c6721551c2ba3973560aef3e11d34ce05db4047', oasisAbi, wallet)
 

--- a/toolbox/scripts/seed-oasis.ts
+++ b/toolbox/scripts/seed-oasis.ts
@@ -1,5 +1,6 @@
 import { PrivateKey } from '../libraries/PrivateKey'
 import { OasisdexContract } from '../libraries/ContractInterfaces'
+import { getEnv } from '../libraries/Environment'
 import { JsonRpcProvider } from 'ethers/providers'
 import { Wallet } from 'ethers/wallet'
 import { BigNumber, bigNumberify } from 'ethers/utils'
@@ -10,13 +11,6 @@ const WETH_ADDRESS = "0xfcaf25bf38e7c86612a25ff18cb8e09ab07c9885"
 
 const ZERO = bigNumberify(0)
 const ETHER = bigNumberify(10).pow(bigNumberify(18))
-
-function getEnv(name: string, fallback?: string): string {
-	const value = process.env[name]
-	if (value !== undefined) return value
-	if (fallback === undefined) throw new Error(`${name} environment variable required`)
-	return fallback
-}
 
 enum OrderType {
 	BID,


### PR DESCRIPTION
Fixes some broken VSCode launch configurations.

Fixes a minor inaccuracy in type definitions for generated contract interfaces.

Fixes a bug with signing in the client-library, GitHub issue also open with ethers.js to try to make this better.

Exposes the address of the various dependency contracts in liquid-long.sol, this makes testing a bit easier as we can get direct access to things like `weth` without having to go through Maker to find it.  Also makes contract auditing on-chain a bit simpler as the user can verify that we are in fact referring to the legit weth/peth/maker contracts.

Adds `deposit-eth.ts` script to the toolbox (and hence the toolbox image).

----

If you are using `docker-compose up` from the root of the repo, then you can run this script against parity with:
```
docker container run --rm -it --network liquid-long_default --link liquid-long_parity_1 --rm -e 'ETHEREUM_HTTP=http://liquid-long_parity_1:8545' keydonix/liquid-long-toolbox deposit-eth.ts
```
You can do something very similar to run it against geth (just change `parity` to `geth` in each case).

If you are running the docker image manually, then you can run this script against that node with:
```
docker container run --rm -it --link <ethereum_node_container_name> --rm -e 'ETHEREUM_HTTP=http://<ethereum_node_container_name>:8545' keydonix/liquid-long-toolbox deposit-eth.ts
```