### PR TITLE
Provides transaction with gas limit of our choosing.

### DIFF
--- a/client-library/library/source/liquid-long-ethers-impl.ts
+++ b/client-library/library/source/liquid-long-ethers-impl.ts
@@ -5,6 +5,7 @@ import { TransactionResponse, TransactionRequest } from 'ethers/providers';
 export interface Provider {
 	listAccounts(): Promise<Array<string>>
 	call(transaction: TransactionRequest): Promise<string>
+	estimateGas(transaction: TransactionRequest): Promise<BigNumber>
 }
 
 export interface Signer {
@@ -26,7 +27,10 @@ export class ContractDependenciesEthers implements Dependencies<BigNumber> {
 	call = async (transaction: Transaction<BigNumber>) => await this.provider.call(transaction)
 	submitTransaction = async (transaction: Transaction<BigNumber>) => {
 		// https://github.com/ethers-io/ethers.js/issues/321
-		transaction = Object.assign({}, transaction)
+		const gasEstimate = (await this.provider.estimateGas(transaction)).toNumber()
+		const gasLimit = Math.min(Math.max(Math.round(gasEstimate * 1.3), 250000), 5000000)
+		// TODO: figure out a way to propagate a warning up to the user in this scenario, we don't currently have a mechanism for error propagation, so will require infrastructure work
+		transaction = Object.assign({}, transaction, { gasLimit: gasLimit })
 		delete transaction.from
 		const receipt = await (await this.signer.sendTransaction(transaction)).wait()
 		// ethers has `status` on the receipt as optional, even though it isn't and never will be undefined if using a modern network (which this is designed for)

--- a/client-library/tests/source/mock-provider.ts
+++ b/client-library/tests/source/mock-provider.ts
@@ -40,4 +40,7 @@ export class MockProvider implements Provider {
 		if (typeof transaction.data === 'string' && transaction.data.startsWith('0x5988899c')) return defaultAbiCoder.encode(['uint256', 'uint256'], [this.attodaiPaidCost, this.attoethBoughtCost])
 		throw new Error("Method not implemented.")
 	}
+	async estimateGas(transaction: TransactionRequest): Promise<BigNumber> {
+		return new BigNumber(3000000)
+	}
 }


### PR DESCRIPTION
Note that we'll follow this set of rules for _all_ gas estimations, which means everything on-chain costs between 250k and 5M and is 1.3x the node's estimated price.  In production, I believe the only transactions that happen on chain are openCdp tranasctions, so this is fine for now, but we may want to revisit this in the future if we start doing more on-chain stuff.

Fixes #71 