### PR TITLE
Adds LiquidLong factories.

### DIFF
--- a/client-library/integration-tests/source/maker-contract-dependencies.ts
+++ b/client-library/integration-tests/source/maker-contract-dependencies.ts
@@ -1,11 +1,11 @@
 import { Dependencies, AbiFunction, AbiParameter, Transaction } from '@keydonix/maker-contract-interfaces'
+import { JsonRpcProvider, JsonRpcSigner } from 'ethers/providers'
 import { keccak256, toUtf8Bytes, BigNumber, AbiCoder } from 'ethers/utils'
-import { Provider, Signer } from '@keydonix/liquid-long-client-library'
 
 export class ContractDependenciesEthers implements Dependencies<BigNumber> {
-	private readonly provider: Provider
-	private readonly signer: Signer
-	public constructor(provider: Provider, signer: Signer) {
+	private readonly provider: JsonRpcProvider
+	private readonly signer: JsonRpcSigner
+	public constructor(provider: JsonRpcProvider, signer: JsonRpcSigner) {
 		this.provider = provider
 		this.signer = signer
 	}

--- a/client-library/library/package-lock.json
+++ b/client-library/library/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@keydonix/liquid-long-client-library",
-	"version": "1.2.3",
+	"version": "1.3.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/client-library/library/package.json
+++ b/client-library/library/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@keydonix/liquid-long-client-library",
-	"version": "1.2.3",
+	"version": "1.3.0",
 	"description": "A client library for Liquid Long.",
 	"main": "output/index.js",
 	"types": "output/index.d.ts",

--- a/client-library/library/source/index.ts
+++ b/client-library/library/source/index.ts
@@ -1,6 +1,1 @@
 export { LiquidLong } from './liquid-long'
-export { Scheduler, TimeoutScheduler } from './scheduler'
-export { PolledValue } from './polled-value'
-export { Provider, Signer } from './liquid-long-ethers-impl'
-export { BigNumber, bigNumberify } from 'ethers/utils'
-export { JsonRpcProvider, TransactionResponse, TransactionRequest, TransactionReceipt } from 'ethers/providers';

--- a/client-library/tests/source/mock-provider.ts
+++ b/client-library/tests/source/mock-provider.ts
@@ -1,4 +1,4 @@
-import { Provider } from '@keydonix/liquid-long-client-library'
+import { Provider } from '@keydonix/liquid-long-client-library/source/liquid-long-ethers-impl'
 import { BigNumber, bigNumberify, defaultAbiCoder } from 'ethers/utils'
 import { TransactionRequest } from 'ethers/providers'
 

--- a/client-library/tests/source/mock-scheduler.ts
+++ b/client-library/tests/source/mock-scheduler.ts
@@ -1,4 +1,4 @@
-import { Scheduler } from '@keydonix/liquid-long-client-library'
+import { Scheduler } from '@keydonix/liquid-long-client-library/source/scheduler'
 
 function delay(milliseconds: number): Promise<void> {
 	return new Promise(resolve => setTimeout(() => resolve(), milliseconds))

--- a/client-library/tests/source/mock-signer.ts
+++ b/client-library/tests/source/mock-signer.ts
@@ -1,7 +1,7 @@
-import { Signer, TransactionRequest, TransactionResponse } from '@keydonix/liquid-long-client-library'
+import { Signer } from '@keydonix/liquid-long-client-library/source/liquid-long-ethers-impl'
 
 export class MockSigner implements Signer {
-	sendTransaction(transaction: TransactionRequest): Promise<TransactionResponse> {
+	sendTransaction(): Promise<any> {
 		throw new Error("Method not implemented.");
 	}
 }

--- a/client-library/tests/source/polled-value-tests.ts
+++ b/client-library/tests/source/polled-value-tests.ts
@@ -1,6 +1,6 @@
 import 'mocha'
 import { expect } from 'chai'
-import { PolledValue } from '@keydonix/liquid-long-client-library'
+import { PolledValue } from '@keydonix/liquid-long-client-library/source/polled-value'
 import { MockScheduler } from './mock-scheduler';
 
 describe('PolledValue', async () => {


### PR DESCRIPTION
The goal here is to make it more obvious/clear how the library is intended to be used, and to also hide the `ethers` implementation detail from users thus allowing us to swap it out in the future.  The primary change is removing almost all exports from `index.ts`.  This makes it clear to userse that they should import `LiquidLong` and nothing else.  To facilitate this, the `LiquidLong` class now has a couple factory methods on it that take mostly mundane parameters (such as strings and numbers).  The one exception is the `web3Provider` parameter which is really just asking for `window.web3.currentProvider` (MetaMask and MetaMask like things).

To make this work, the library needs to reach inside the library in a couple places for testing.  I'm generally not a fan of this pattern, but have left it in for now as something to be addressed later.  I believe the correct solution here would be to split the project up into several packages that are tested and released separately, but that is probably overkill at this point.