### PR TITLE
Changes the way Ethers importing is done to make library work in brower.

### DIFF
--- a/client-library/library/package-lock.json
+++ b/client-library/library/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@keydonix/liquid-long-client-library",
-	"version": "1.3.0",
+	"version": "1.3.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/client-library/library/package.json
+++ b/client-library/library/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@keydonix/liquid-long-client-library",
-	"version": "1.3.0",
+	"version": "1.3.1",
 	"description": "A client library for Liquid Long.",
 	"main": "output/index.js",
 	"types": "output/index.d.ts",

--- a/client-library/library/source/liquid-long-ethers-impl.ts
+++ b/client-library/library/source/liquid-long-ethers-impl.ts
@@ -1,18 +1,18 @@
 import { Dependencies, AbiFunction, AbiParameter, Transaction, TransactionReceipt } from './generated/liquid-long'
-import { keccak256, toUtf8Bytes, BigNumber, AbiCoder } from 'ethers/utils'
-import { TransactionResponse, TransactionRequest } from 'ethers/providers';
+import { utils as EthersUtils, providers as EthersProviders } from 'ethers'
+export { EthersUtils, EthersProviders }
 
 export interface Provider {
 	listAccounts(): Promise<Array<string>>
-	call(transaction: TransactionRequest): Promise<string>
-	estimateGas(transaction: TransactionRequest): Promise<BigNumber>
+	call(transaction: EthersProviders.TransactionRequest): Promise<string>
+	estimateGas(transaction: EthersProviders.TransactionRequest): Promise<EthersUtils.BigNumber>
 }
 
 export interface Signer {
-	sendTransaction(transaction: TransactionRequest): Promise<TransactionResponse>;
+	sendTransaction(transaction: EthersProviders.TransactionRequest): Promise<EthersProviders.TransactionResponse>;
 }
 
-export class ContractDependenciesEthers implements Dependencies<BigNumber> {
+export class ContractDependenciesEthers implements Dependencies<EthersUtils.BigNumber> {
 	private readonly provider: Provider
 	private readonly signer: Signer
 	public constructor(provider: Provider, signer: Signer) {
@@ -20,12 +20,12 @@ export class ContractDependenciesEthers implements Dependencies<BigNumber> {
 		this.signer = signer
 	}
 
-	keccak256 = (utf8String: string) => keccak256(toUtf8Bytes(utf8String))
-	encodeParams = (abiFunction: AbiFunction, parameters: Array<any>) => new AbiCoder().encode(abiFunction.inputs, parameters).substr(2)
-	decodeParams = (abiParameters: Array<AbiParameter>, encoded: string) => new AbiCoder().decode(abiParameters, encoded)
+	keccak256 = (utf8String: string) => EthersUtils.keccak256(EthersUtils.toUtf8Bytes(utf8String))
+	encodeParams = (abiFunction: AbiFunction, parameters: Array<any>) => new EthersUtils.AbiCoder().encode(abiFunction.inputs, parameters).substr(2)
+	decodeParams = (abiParameters: Array<AbiParameter>, encoded: string) => new EthersUtils.AbiCoder().decode(abiParameters, encoded)
 	getDefaultAddress = async () => (await this.provider.listAccounts())[0]
-	call = async (transaction: Transaction<BigNumber>) => await this.provider.call(transaction)
-	submitTransaction = async (transaction: Transaction<BigNumber>) => {
+	call = async (transaction: Transaction<EthersUtils.BigNumber>) => await this.provider.call(transaction)
+	submitTransaction = async (transaction: Transaction<EthersUtils.BigNumber>) => {
 		// https://github.com/ethers-io/ethers.js/issues/321
 		const gasEstimate = (await this.provider.estimateGas(transaction)).toNumber()
 		const gasLimit = Math.min(Math.max(Math.round(gasEstimate * 1.3), 250000), 5000000)

--- a/client-library/tests/source/mock-provider.ts
+++ b/client-library/tests/source/mock-provider.ts
@@ -1,46 +1,44 @@
-import { Provider } from '@keydonix/liquid-long-client-library/source/liquid-long-ethers-impl'
-import { BigNumber, bigNumberify, defaultAbiCoder } from 'ethers/utils'
-import { TransactionRequest } from 'ethers/providers'
+import { Provider, EthersUtils, EthersProviders } from '@keydonix/liquid-long-client-library/source/liquid-long-ethers-impl'
 
-export const QUINTILLION = bigNumberify(1e9).mul(1e9)
+export const QUINTILLION = EthersUtils.bigNumberify(1e9).mul(1e9)
 
 export class MockProvider implements Provider {
 	public accounts: Array<string> = []
-	public ethPriceInAttousd: BigNumber = bigNumberify(QUINTILLION).mul(Math.round(Math.random() * 100 + 1))
-	public providerFeePerEth: BigNumber = bigNumberify(QUINTILLION).mul(Math.round(Math.random() * 100 + 1))
-	public attodaiPaidCost: BigNumber = bigNumberify(QUINTILLION).mul(Math.round(Math.random() * 100 + 1))
-	public attoethBoughtCost: BigNumber = bigNumberify(QUINTILLION).mul(Math.round(Math.random() * 100 + 1))
+	public ethPriceInAttousd: EthersUtils.BigNumber = EthersUtils.bigNumberify(QUINTILLION).mul(Math.round(Math.random() * 100 + 1))
+	public providerFeePerEth: EthersUtils.BigNumber = EthersUtils.bigNumberify(QUINTILLION).mul(Math.round(Math.random() * 100 + 1))
+	public attodaiPaidCost: EthersUtils.BigNumber = EthersUtils.bigNumberify(QUINTILLION).mul(Math.round(Math.random() * 100 + 1))
+	public attoethBoughtCost: EthersUtils.BigNumber = EthersUtils.bigNumberify(QUINTILLION).mul(Math.round(Math.random() * 100 + 1))
 
 	setEthPriceInUsd(value: number) {
-		this.ethPriceInAttousd = bigNumberify(Math.round(value * 1e9)).mul(1e9)
+		this.ethPriceInAttousd = EthersUtils.bigNumberify(Math.round(value * 1e9)).mul(1e9)
 	}
 
 	setProviderFeePerEth(value: number) {
-		this.providerFeePerEth = bigNumberify(Math.round(value * 1e9)).mul(1e9)
+		this.providerFeePerEth = EthersUtils.bigNumberify(Math.round(value * 1e9)).mul(1e9)
 	}
 
 	setDaiPaidCost(value: number) {
-		this.attodaiPaidCost = bigNumberify(Math.round(value * 1e9)).mul(1e9)
+		this.attodaiPaidCost = EthersUtils.bigNumberify(Math.round(value * 1e9)).mul(1e9)
 	}
 
 	setEthBoughtCost(value: number) {
-		this.attoethBoughtCost = bigNumberify(Math.round(value * 1e9)).mul(1e9)
+		this.attoethBoughtCost = EthersUtils.bigNumberify(Math.round(value * 1e9)).mul(1e9)
 	}
 
 	async listAccounts(): Promise<string[]> {
 		return this.accounts
 	}
-	async call(transaction: TransactionRequest): Promise<string> {
+	async call(transaction: EthersProviders.TransactionRequest): Promise<string> {
 		// getEthPrice()
-		if (transaction.data === '0x683e0bcd') return defaultAbiCoder.encode(['uint256'], [this.ethPriceInAttousd])
+		if (transaction.data === '0x683e0bcd') return EthersUtils.defaultAbiCoder.encode(['uint256'], [this.ethPriceInAttousd])
 		// providerFeePerEth()
-		if (transaction.data === '0xfa72c53e') return defaultAbiCoder.encode(['uint256'], [this.providerFeePerEth])
+		if (transaction.data === '0xfa72c53e') return EthersUtils.defaultAbiCoder.encode(['uint256'], [this.providerFeePerEth])
 		// TODO: make this decode the inputs and compute a reasonable output
 		// estimateDaiSaleProceeds(uint256)
-		if (typeof transaction.data === 'string' && transaction.data.startsWith('0x5988899c')) return defaultAbiCoder.encode(['uint256', 'uint256'], [this.attodaiPaidCost, this.attoethBoughtCost])
+		if (typeof transaction.data === 'string' && transaction.data.startsWith('0x5988899c')) return EthersUtils.defaultAbiCoder.encode(['uint256', 'uint256'], [this.attodaiPaidCost, this.attoethBoughtCost])
 		throw new Error("Method not implemented.")
 	}
-	async estimateGas(transaction: TransactionRequest): Promise<BigNumber> {
-		return new BigNumber(3000000)
+	async estimateGas(transaction: EthersProviders.TransactionRequest): Promise<EthersUtils.BigNumber> {
+		return new EthersUtils.BigNumber(3000000)
 	}
 }


### PR DESCRIPTION
The Ethers library has two sets of outputs, one that lives in the root of the project and one that lives in `dist` subdirectory.  The `dist` subdirectory is compiled targeting browser, while the rest is compiled targeting NodeJS.  When you do an import of a library using `import { ... } from 'library/path'` it ignores the `package.json` paths and accesses the library directly at that path.  This means that if you do `import { ... } from 'ethers/utils'` it will always be pulling in the NodeJS version, even when you are targeting the browser.

To complicate matters, TSC seemse to be unhappy with the way `ethers` exports are setup and it complains if a dependency of this library tries to do `import { utils } from 'ethers'` and fulfill a type requirement in the library where it also has a similar import.  To resolve this, the library now re-exports the Ethers pieces that are necessary to create a custom Provider.  This should only be necessary for testing/mocking things, so end-users shouldn't ever see or notice this change.

The important high-level takeaway from this change is that the library is now friendly to being used in the browser.  It has been tested against a previously failing Angular app (which bundles with Webpack under the hood) and everything is now working.