### PR TITLE
Improves library estimate and adds constraint to contracts.

### DIFF
--- a/client-library/library/source/liquid-long.ts
+++ b/client-library/library/source/liquid-long.ts
@@ -99,7 +99,7 @@ export class LiquidLong {
 		const result = await this.contract.estimateDaiSaleProceeds_(attodaiToSell)
 		const daiSaleProceedsInEth = result._wethBought.div(1e9).toNumber() / 1e9
 		const estimatedCostInEth = loanSizeInEth - daiSaleProceedsInEth
-		const low = estimatedCostInEth
+		const low = Math.max(estimatedCostInEth, loanSizeInEth * 0.01)
 		const high = Math.max(low * 2, loanSizeInEth * 0.05)
 		return { low, high }
 	}


### PR DESCRIPTION
Makes library return `max(estimated_cost, loan_size * 0.01)` so that the user will never have 0 for estimated costs.  This will increase the chances of the transaction going through successfully, and they'll get a refund in those cases.

Added a constraint to `openCdp` that ensures the contract ends with the same amount of WETH it started with.  This should never fail, but if someone finds a way to attack the contract this is an added layer of protection.  This change blew the stack depth limit, so I had to extract some code out into a helper function.