### PR TITLE
Library now outputs both commonjs and es2015 modules.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 **/node_modules/
 **/output/
+**/output-es/
+**/output-node/
 /client-library/library/source/generated/
 /toolbox/libraries/liquid-long.ts

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -112,7 +112,7 @@
 			"cwd": "${workspaceFolder}/client-library/tests/",
 			"program": "${workspaceFolder}/client-library/tests/node_modules/mocha/bin/_mocha",
 			"args": [ "--require", "ts-node/register", "--timeout", "999999", "--colors", "source/**/*.ts" ],
-			"preLaunchTask": "build client library",
+			"preLaunchTask": "build-client-library",
 		},
 		{
 			"type": "node",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,12 +4,11 @@
 	"version": "2.0.0",
 	"tasks": [
 		{
-			"identifier": "build client library",
-			"type": "typescript",
-			"tsconfig": "client-library\\library\\tsconfig.json",
-			"problemMatcher": [
-				"$tsc"
-			]
+			"label": "build-client-library",
+			"type": "npm",
+			"script": "build",
+			"path": "client-library/library/",
+			"problemMatcher": []
 		}
 	]
 }

--- a/Readme.md
+++ b/Readme.md
@@ -34,7 +34,7 @@ or
 ```
 cd client-library/library
 npm install
-npx tsc
+npm run build
 ```
 
 ## Testing and Using with a UI

--- a/client-library/Dockerfile
+++ b/client-library/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8-alpine
+FROM node:lts-alpine
 
 # cache dependencies when possible
 COPY library/package.json /app/library/package.json
@@ -11,9 +11,18 @@ COPY integration-tests/package-lock.json /app/integration-tests/package-lock.jso
 WORKDIR /app/integration-tests
 RUN npm install
 
+COPY tests/package.json /app/tests/package.json
+COPY tests/package-lock.json /app/tests/package-lock.json
+WORKDIR /app/tests
+RUN npm install
+
 COPY library/ /app/library/
 WORKDIR /app/library
-RUN npx tsc
+RUN npm run build
+
+COPY tests/ /app/tests/
+WORKDIR /app/tests
+RUN npm run test-no-build
 
 COPY integration-tests/ /app/integration-tests/
 WORKDIR /app/integration-tests

--- a/client-library/integration-tests/package-lock.json
+++ b/client-library/integration-tests/package-lock.json
@@ -9,7 +9,7 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "10.5.8",
+					"version": "10.12.18",
 					"bundled": true
 				},
 				"aes-js": {
@@ -28,19 +28,19 @@
 					"version": "6.3.3",
 					"bundled": true,
 					"requires": {
-						"bn.js": "4.11.8",
-						"brorand": "1.1.0",
-						"hash.js": "1.1.3",
-						"inherits": "2.0.3"
+						"bn.js": "^4.4.0",
+						"brorand": "^1.0.1",
+						"hash.js": "^1.0.0",
+						"inherits": "^2.0.1"
 					}
 				},
 				"ethers": {
-					"version": "4.0.3",
+					"version": "4.0.7",
 					"bundled": true,
 					"requires": {
-						"@types/node": "10.5.8",
+						"@types/node": "^10.3.2",
 						"aes-js": "3.0.0",
-						"bn.js": "4.11.8",
+						"bn.js": "^4.4.0",
 						"elliptic": "6.3.3",
 						"hash.js": "1.1.3",
 						"js-sha3": "0.5.7",
@@ -54,8 +54,8 @@
 					"version": "1.1.3",
 					"bundled": true,
 					"requires": {
-						"inherits": "2.0.3",
-						"minimalistic-assert": "1.0.1"
+						"inherits": "^2.0.3",
+						"minimalistic-assert": "^1.0.0"
 					}
 				},
 				"inherits": {

--- a/client-library/integration-tests/source/integration.ts
+++ b/client-library/integration-tests/source/integration.ts
@@ -3,7 +3,7 @@ require('source-map-support').install()
 import 'mocha'
 import { expect } from 'chai'
 import { LiquidLong } from '@keydonix/liquid-long-client-library'
-import { TimeoutScheduler } from '@keydonix/liquid-long-client-library/output/scheduler';
+import { TimeoutScheduler } from '@keydonix/liquid-long-client-library/output-node/scheduler';
 import { Oasis, Sai, Gem, Tub, Pip } from '@keydonix/maker-contract-interfaces'
 import { ContractDependenciesEthers } from './maker-contract-dependencies'
 import { getEnv } from './environment'

--- a/client-library/library/package-lock.json
+++ b/client-library/library/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@keydonix/liquid-long-client-library",
-	"version": "2.1.0",
+	"version": "3.0.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -75,6 +75,12 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
 			"integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+		},
+		"recursive-fs": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/recursive-fs/-/recursive-fs-1.1.0.tgz",
+			"integrity": "sha512-lQ5N73NysDdckjvoDL9q+88MDkid/mEbfbJLdE/sPqPI/vyOadz3nP9THcxu58aZUkJ8FqLEeyh1EFwCoC0BwA==",
+			"dev": true
 		},
 		"scrypt-js": {
 			"version": "2.0.4",

--- a/client-library/library/package.json
+++ b/client-library/library/package.json
@@ -1,9 +1,9 @@
 {
 	"name": "@keydonix/liquid-long-client-library",
-	"version": "2.1.0",
+	"version": "3.0.0",
 	"description": "A client library for Liquid Long.",
-	"main": "output/index.js",
-	"types": "output/index.d.ts",
+	"main": "output-node/index.js",
+	"browser": "output-es/index.js",
 	"sideEffects": false,
 	"repository": {
 		"type": "git",
@@ -16,12 +16,14 @@
 	},
 	"homepage": "https://github.com/Keydonix/liquid-long#readme",
 	"scripts": {
-		"test": "cd ../tests && npm install && npm run test",
+		"clean": "recursive-delete \"output-es\" && recursive-delete \"output-node\"",
+		"build": "npx tsc --project tsconfig-es.json && npx tsc --project tsconfig-node.json",
+		"test": "npm run build && npm run test-no-build",
 		"test-no-build": "cd ../tests && npm run test-no-build",
-		"prepublishOnly": "npm run test"
+		"prepublishOnly": "npm run clean && npm run test"
 	},
 	"devDependencies": {
-		"@types/node": "10.5.8",
+		"recursive-fs": "1.1.0",
 		"typescript": "3.1.6"
 	},
 	"dependencies": {

--- a/client-library/library/source/index.ts
+++ b/client-library/library/source/index.ts
@@ -1,1 +1,1 @@
-export { LiquidLong } from './liquid-long'
+export { LiquidLong } from './liquid-long.js'

--- a/client-library/library/source/liquid-long-ethers-impl.ts
+++ b/client-library/library/source/liquid-long-ethers-impl.ts
@@ -1,4 +1,4 @@
-import { Dependencies, AbiFunction, AbiParameter, Transaction, TransactionReceipt } from './generated/liquid-long'
+import { Dependencies, AbiFunction, AbiParameter, Transaction, TransactionReceipt } from './generated/liquid-long.js'
 import { ethers } from 'ethers'
 
 

--- a/client-library/library/source/liquid-long.ts
+++ b/client-library/library/source/liquid-long.ts
@@ -1,8 +1,8 @@
-import { LiquidLong as LiquidLongContract } from './generated/liquid-long'
-import { ContractDependenciesEthers, Provider, Signer } from './liquid-long-ethers-impl'
-import { Scheduler, TimeoutScheduler } from './scheduler'
-import { PolledValue } from './polled-value'
-import { parseHexInt } from './utils'
+import { LiquidLong as LiquidLongContract } from './generated/liquid-long.js'
+import { ContractDependenciesEthers, Provider, Signer } from './liquid-long-ethers-impl.js'
+import { Scheduler, TimeoutScheduler } from './scheduler.js'
+import { PolledValue } from './polled-value.js'
+import { parseHexInt } from './utils.js'
 import { ethers } from 'ethers'
 
 

--- a/client-library/library/source/polled-value.ts
+++ b/client-library/library/source/polled-value.ts
@@ -1,4 +1,4 @@
-import { Scheduler } from './scheduler'
+import { Scheduler } from './scheduler.js'
 
 export class PolledValue<TValue> {
 	private readonly scheduler: Scheduler

--- a/client-library/library/tsconfig-es.json
+++ b/client-library/library/tsconfig-es.json
@@ -1,0 +1,21 @@
+{
+	"compilerOptions": {
+		"target": "es2017",
+		"module": "es2015",
+		"moduleResolution": "node",
+		"outDir": "output-es",
+		"rootDir": "source",
+		"sourceMap": true,
+		"inlineSources": true,
+		"strict": true,
+		"noEmitOnError": true,
+		"noImplicitAny": true,
+		"noImplicitThis": true,
+		"noImplicitReturns": true,
+		"declaration": true,
+		"lib": [ "es2018" ]
+	},
+	"include": [
+		"**/*.ts",
+	]
+}

--- a/client-library/library/tsconfig-node.json
+++ b/client-library/library/tsconfig-node.json
@@ -3,7 +3,7 @@
 		"target": "es2017",
 		"module": "commonjs",
 		"moduleResolution": "node",
-		"outDir": "output",
+		"outDir": "output-node",
 		"rootDir": "source",
 		"sourceMap": true,
 		"inlineSources": true,
@@ -13,7 +13,7 @@
 		"noImplicitThis": true,
 		"noImplicitReturns": true,
 		"declaration": true,
-		"lib": [ "es6" ],
+		"lib": [ "es2018" ]
 	},
 	"include": [
 		"**/*.ts",

--- a/client-library/tests/package-lock.json
+++ b/client-library/tests/package-lock.json
@@ -2,6 +2,100 @@
 	"requires": true,
 	"lockfileVersion": 1,
 	"dependencies": {
+		"@keydonix/liquid-long-client-library": {
+			"version": "file:../library",
+			"requires": {
+				"ethers": "4.0.7"
+			},
+			"dependencies": {
+				"@types/node": {
+					"version": "10.5.8",
+					"bundled": true
+				},
+				"aes-js": {
+					"version": "3.0.0",
+					"bundled": true
+				},
+				"bn.js": {
+					"version": "4.11.8",
+					"bundled": true
+				},
+				"brorand": {
+					"version": "1.1.0",
+					"bundled": true
+				},
+				"elliptic": {
+					"version": "6.3.3",
+					"bundled": true,
+					"requires": {
+						"bn.js": "^4.4.0",
+						"brorand": "^1.0.1",
+						"hash.js": "^1.0.0",
+						"inherits": "^2.0.1"
+					}
+				},
+				"ethers": {
+					"version": "4.0.7",
+					"bundled": true,
+					"requires": {
+						"@types/node": "^10.3.2",
+						"aes-js": "3.0.0",
+						"bn.js": "^4.4.0",
+						"elliptic": "6.3.3",
+						"hash.js": "1.1.3",
+						"js-sha3": "0.5.7",
+						"scrypt-js": "2.0.4",
+						"setimmediate": "1.0.4",
+						"uuid": "2.0.1",
+						"xmlhttprequest": "1.8.0"
+					}
+				},
+				"hash.js": {
+					"version": "1.1.3",
+					"bundled": true,
+					"requires": {
+						"inherits": "^2.0.3",
+						"minimalistic-assert": "^1.0.0"
+					}
+				},
+				"inherits": {
+					"version": "2.0.3",
+					"bundled": true
+				},
+				"js-sha3": {
+					"version": "0.5.7",
+					"bundled": true
+				},
+				"minimalistic-assert": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"recursive-fs": {
+					"version": "1.1.0",
+					"bundled": true
+				},
+				"scrypt-js": {
+					"version": "2.0.4",
+					"bundled": true
+				},
+				"setimmediate": {
+					"version": "1.0.4",
+					"bundled": true
+				},
+				"typescript": {
+					"version": "3.1.6",
+					"bundled": true
+				},
+				"uuid": {
+					"version": "2.0.1",
+					"bundled": true
+				},
+				"xmlhttprequest": {
+					"version": "1.8.0",
+					"bundled": true
+				}
+			}
+		},
 		"@types/chai": {
 			"version": "4.1.4",
 			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.1.4.tgz",

--- a/client-library/tests/package.json
+++ b/client-library/tests/package.json
@@ -1,15 +1,12 @@
 {
 	"private": true,
 	"scripts": {
-		"build-dependency": "cd ../library && npm install && tsc",
-		"unlink-dependency": "npm unlink ../library",
-		"link-dependency": "npm link ../library",
-		"preinstall": "npm run unlink-dependency",
-		"postinstall": "npm run build-dependency && npm run link-dependency",
+		"build-dependency": "cd ../library && npm install && npm run build",
 		"test-no-build": "mocha --require ts-node/register --colors source/**/*.ts",
 		"test": "npm run build-dependency && npm run test-no-build"
 	},
 	"dependencies": {
+		"@keydonix/liquid-long-client-library": "file:../library",
 		"@types/chai": "4.1.4",
 		"@types/chai-as-promised": "7.1.0",
 		"@types/mocha": "5.2.3",

--- a/toolbox/package-lock.json
+++ b/toolbox/package-lock.json
@@ -56,10 +56,10 @@
 			"integrity": "sha1-VILZZG1UvLif19mU/J4ulWiHbj8=",
 			"dev": true,
 			"requires": {
-				"bn.js": "4.11.8",
-				"brorand": "1.1.0",
-				"hash.js": "1.1.3",
-				"inherits": "2.0.3"
+				"bn.js": "^4.4.0",
+				"brorand": "^1.0.1",
+				"hash.js": "^1.0.0",
+				"inherits": "^2.0.1"
 			}
 		},
 		"ethers": {
@@ -68,9 +68,9 @@
 			"integrity": "sha512-l4SUYWYamqwaZiDvIB39Og6riD23/jaWuj8QrdpcfBi20QUZ89IxQtD8S+IHge7tzh962cp13N8gfCXWaP5ZWQ==",
 			"dev": true,
 			"requires": {
-				"@types/node": "10.11.5",
+				"@types/node": "^10.3.2",
 				"aes-js": "3.0.0",
-				"bn.js": "4.11.8",
+				"bn.js": "^4.4.0",
 				"elliptic": "6.3.3",
 				"hash.js": "1.1.3",
 				"js-sha3": "0.5.7",
@@ -94,8 +94,8 @@
 			"integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
 			"dev": true,
 			"requires": {
-				"inherits": "2.0.3",
-				"minimalistic-assert": "1.0.1"
+				"inherits": "^2.0.3",
+				"minimalistic-assert": "^1.0.0"
 			}
 		},
 		"inherits": {
@@ -169,8 +169,8 @@
 			"integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
 			"dev": true,
 			"requires": {
-				"buffer-from": "1.1.1",
-				"source-map": "0.6.1"
+				"buffer-from": "^1.0.0",
+				"source-map": "^0.6.0"
 			}
 		},
 		"ts-node": {
@@ -179,14 +179,14 @@
 			"integrity": "sha512-BVwVbPJRspzNh2yfslyT1PSbl5uIk03EZlb493RKHN4qej/D06n1cEhjlOJG69oFsE7OT8XjpTUcYf6pKTLMhw==",
 			"dev": true,
 			"requires": {
-				"arrify": "1.0.1",
-				"buffer-from": "1.1.1",
-				"diff": "3.5.0",
-				"make-error": "1.3.5",
-				"minimist": "1.2.0",
-				"mkdirp": "0.5.1",
-				"source-map-support": "0.5.9",
-				"yn": "2.0.0"
+				"arrify": "^1.0.0",
+				"buffer-from": "^1.1.0",
+				"diff": "^3.1.0",
+				"make-error": "^1.1.1",
+				"minimist": "^1.2.0",
+				"mkdirp": "^0.5.1",
+				"source-map-support": "^0.5.6",
+				"yn": "^2.0.0"
 			}
 		},
 		"typescript": {


### PR DESCRIPTION
Major version bump since we are moving where the filese are and some workflows may break as a result.

The `.js` suffix in the TS files is an unfortunate consequence of ES modules requiring full filenames and TSC not having an option to add the extension as part of the compile process.  It works and is supported, even though it is dumb.

The changes to the TimeoutScheduler are because previously we were depending on NodeJS specific types and we got lucky that it happened to work in the browser as well.  While the code didn't change, the type checker now is more correctly checking the type.  At runtime the task ID will be either always `number` or always `NodeJS.Timer` depending on environment.