### PR TITLE
Removes default values from polled values.

### DIFF
--- a/client-library/integration-tests/source/integration.ts
+++ b/client-library/integration-tests/source/integration.ts
@@ -51,9 +51,9 @@ describe('liquid long tests', async () => {
 			affiliate: Wallet.fromMnemonic('fantasy fringe prosper bench jaguar sound corn course stick blade luggage wonder').connect(provider),
 		}
 		liquidLong = {
-			owner: LiquidLong.createJsonRpc(ethereumAddress, liquidLongAddress, 0, 0.01, 0, 10),
-			user: new LiquidLong(new TimeoutScheduler(), provider, wallets.user, liquidLongAddress, 0, 0.01, 0),
-			affiliate: new LiquidLong(new TimeoutScheduler(), provider, wallets.affiliate, liquidLongAddress, 0, 0.01, 0),
+			owner: LiquidLong.createJsonRpc(ethereumAddress, liquidLongAddress, 0, 10),
+			user: new LiquidLong(new TimeoutScheduler(), provider, wallets.user, liquidLongAddress, 0),
+			affiliate: new LiquidLong(new TimeoutScheduler(), provider, wallets.affiliate, liquidLongAddress, 0),
 		}
 		const ownerDependencies = new ContractDependenciesEthers(provider, provider.getSigner(0))
 		const userDependencies = new ContractDependenciesEthers(provider, wallets.user)

--- a/client-library/library/package.json
+++ b/client-library/library/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@keydonix/liquid-long-client-library",
-	"version": "3.0.0",
+	"version": "4.0.0",
 	"description": "A client library for Liquid Long.",
 	"main": "output-node/index.js",
 	"browser": "output-es/index.js",
@@ -23,7 +23,7 @@
 		"prepublishOnly": "npm run clean && npm run test"
 	},
 	"devDependencies": {
-		"recursive-fs": "1.1.0",
+		"recursive-fs": "1.1.1",
 		"typescript": "3.1.6"
 	},
 	"dependencies": {

--- a/client-library/library/tsconfig.json
+++ b/client-library/library/tsconfig.json
@@ -1,0 +1,3 @@
+{
+	"extends": "./tsconfig-es.json"
+}

--- a/client-library/tests/source/polled-value-tests.ts
+++ b/client-library/tests/source/polled-value-tests.ts
@@ -15,35 +15,34 @@ describe('PolledValue', async () => {
 		scheduler.cancelAll()
 	})
 
-	it('should return provided default immediately', async () => {
-		polledNumber = new PolledValue(scheduler, async () => { await scheduler.delay(1); return 5 }, 2, 3)
-		expect(polledNumber.cached).to.equal(3)
+	it('cached value should trigger fetch at first', async () => {
+		let fetcherCalled = false
+		const fetcher = async () => { fetcherCalled = true; await scheduler.delay(1); return 3 }
+		polledNumber = new PolledValue(scheduler, fetcher, 2)
+		expect(fetcherCalled).to.be.true
 	})
 
 	it('should fetch immediately when instantiated', async () => {
-		polledNumber = new PolledValue(scheduler, async () => { await scheduler.delay(1); return 5 }, 2, 3)
-		expect(polledNumber.cached).to.equal(3)
+		polledNumber = new PolledValue(scheduler, async () => { await scheduler.delay(1); return 5 }, 2)
 		// we must wait 1 millisecond for the fetcher to return
 		await scheduler.moveTimeForward(1)
-		expect(polledNumber.cached).to.equal(5)
+		expect(await polledNumber.cached).to.equal(5)
 	})
 
 	it('should update when polled again', async () => {
-		const defaultValue = 1
-		let returnedValue = defaultValue
-		polledNumber = new PolledValue(scheduler, async () => { await scheduler.delay(1); return ++returnedValue }, 2, defaultValue)
-		expect(polledNumber.cached).to.equal(1)
+		let returnedValue = 1
+		polledNumber = new PolledValue(scheduler, async () => { await scheduler.delay(1); return ++returnedValue }, 2)
 		await scheduler.moveTimeForward(1)
 		// initial fetch was kicked off immediately, but the fetch takes 1 millisecond so it should have updated by now
-		expect(polledNumber.cached).to.equal(2)
+		expect(await polledNumber.cached).to.equal(2)
 		await scheduler.moveTimeForward(1)
 		// polling interval is 2 milliseconds and was started when first fetch completed, so not time to fetch again yet
-		expect(polledNumber.cached).to.equal(2)
+		expect(await polledNumber.cached).to.equal(2)
 		await scheduler.moveTimeForward(1)
 		// 2 milliseconds has passed since first fetch completed, which triggers fetcher, but the fetch is not instantaneous so cached value not yet updated
-		expect(polledNumber.cached).to.equal(2)
+		expect(await polledNumber.cached).to.equal(2)
 		await scheduler.moveTimeForward(1)
 		// finally the fetcher function returns and we have the next value
-		expect(polledNumber.cached).to.equal(3)
+		expect(await polledNumber.cached).to.equal(3)
 	})
 })


### PR DESCRIPTION
These defaults made coding easier because we had a `number` instead of `number | null` but they prevented us from differentiating between "loading" and "loaded".  This change is breaking (hence the major version bump) but I believe it is the right move, and I'm not sure why I decided to not do this in the first place.

The recursive-fs update just makes it so the CLI doesn't print an empty line on success or an error on delete when the directory doesn't exist (QoL improvements).

The new tsconfig.json is just so VS Code is capable of processing the files, since it will _only_ use a file named `tsconfig.json`.