### PR TITLE
Add static call to getCdps

### DIFF
--- a/contracts/source/liquid-long.sol
+++ b/contracts/source/liquid-long.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity 0.4.25;
 pragma experimental ABIEncoderV2;
 pragma experimental "v0.5.0";
 

--- a/contracts/source/liquid-long.sol
+++ b/contracts/source/liquid-long.sol
@@ -391,6 +391,17 @@ contract LiquidLong is Ownable, Claimable, Pausable {
 
 	ProxyRegistry public proxyRegistry;
 
+	struct CDP {
+		uint256 id;
+		uint256 debtInAttodai;
+		uint256 lockedAttoeth;
+		uint256 feeInAttoeth;
+		uint256 liquidationCostInAttoeth;
+		uint256 liquidatableDebtInAttodai;
+		uint256 liquidationCostAtFeedPriceInAttoeth;
+		bool userOwned;
+	}
+
 	event NewCup(address user, bytes32 cup);
 
 	constructor(Oasis _oasis, Maker _maker, ProxyRegistry _proxyRegistry) public payable {
@@ -473,6 +484,30 @@ contract LiquidLong is Ownable, Claimable, Pausable {
 		return (_paidAmount, _boughtAmount);
 	}
 
+	function estimateDaiPurchaseCosts(uint256 _attodaiToBuy) public view returns (uint256 _wethPaid, uint256 _daiBought) {
+		return getBuyPriceAndAmount(weth, dai, _attodaiToBuy);
+	}
+
+	// buy/pay are from the perspective of the taker/caller (Oasis contracts use buy/pay terminology from perspective of the maker)
+	function getBuyPriceAndAmount(ERC20 _payGem, ERC20 _buyGem, uint256 _buyDesiredAmount) public view returns (uint256 _paidAmount, uint256 _boughtAmount) {
+		uint256 _offerId = oasis.getBestOffer(_buyGem, _payGem);
+		while (_offerId != 0) {
+			uint256 _buyRemaining = _buyDesiredAmount.sub(_boughtAmount);
+			(uint256 _buyAvailableInOffer, , uint256 _payAvailableInOffer,) = oasis.getOffer(_offerId);
+			if (_buyRemaining <= _buyAvailableInOffer) {
+				// TODO: safe math after verifying this logic is correct
+				uint256 _payRemaining = (_buyRemaining * _payAvailableInOffer / _buyAvailableInOffer);
+				_paidAmount = _paidAmount.add(_payRemaining);
+				_boughtAmount = _boughtAmount.add(_buyRemaining);
+				break;
+			}
+			_paidAmount = _paidAmount.add(_payAvailableInOffer);
+			_boughtAmount = _boughtAmount.add(_buyAvailableInOffer);
+			_offerId = oasis.getWorseOffer(_offerId);
+		}
+		return (_paidAmount, _boughtAmount);
+	}
+
 	modifier wethBalanceIncreased() {
 		uint256 _startingAttowethBalance = weth.balanceOf(this);
 		_;
@@ -531,5 +566,54 @@ contract LiquidLong is Ownable, Claimable, Pausable {
 			weth.withdraw(_refundDue);
 			require(msg.sender.call.value(_refundDue)());
 		}
+	}
+
+	// Retrieve CDPs by EFFECTIVE owner, which address owns the DSProxy which owns the CDPs
+	function getCdps(address _ownerOfProxy, uint256 _offset, uint256 _pageSize) public returns (CDP[] _cdps) {
+		// resolve a owner to a proxy, then query by that proxy
+		DSProxy _cdpProxy = proxyRegistry.proxies(_ownerOfProxy);
+		require(_cdpProxy != address(0));
+		return getCdpsByOwner(_cdpProxy, _offset, _pageSize);
+	}
+
+	// Retrieve CDPs by TRUE owner, as registered in MAker
+	function getCdpsByOwner(address _ownerOfCdp, uint256 _offset, uint256 _pageSize) public returns (CDP[] _cdps) {
+		uint256 _cdpCount = cdpCount();
+		uint256 _matchCount = 0;
+		for (uint256 _i = _offset; _i <= _cdpCount && _i < _offset + _pageSize; ++_i) {
+			address _cdpOwner = maker.lad(bytes32(_i));
+			if (_cdpOwner != _ownerOfCdp) continue;
+			++_matchCount;
+		}
+		_cdps = new CDP[](_matchCount);
+		_matchCount = 0;
+		for (uint256 _i = _offset; _i <= _cdpCount && _i < _offset + _pageSize; ++_i) {
+			(address _cdpOwner, uint256 _collateral,,) = maker.cups(bytes32(_i));
+			if (_cdpOwner != _ownerOfCdp) continue;
+			// this one line makes this function not `view`. tab calls chi, which calls drip which mutates state and we can't directly access _chi to bypass this
+			uint256 _debtInAttodai = maker.tab(bytes32(_i));
+			// Adjust locked attoeth to factor in peth/weth ratio
+			uint256 _lockedAttoeth = (_collateral + 1).mul27(maker.gap().mul18(maker.per()));
+			// We use two values in case order book can not satisfy closing CDP
+			// Can be closed if _liqudationDebtInAttodai == _debtInAttodai
+			(uint256 _liquidationCostInAttoeth, uint256 _liquidatableDebtInAttodai) = estimateDaiPurchaseCosts(_debtInAttodai);
+			uint256 _liquidationCostAtFeedPriceInAttoeth = _debtInAttodai.div18(ethPriceInUsd());
+			_cdps[_matchCount] = CDP({
+				id: _i,
+				debtInAttodai: _debtInAttodai,
+				lockedAttoeth: _lockedAttoeth,
+				feeInAttoeth: _liquidationCostInAttoeth / 100,
+				liquidationCostInAttoeth: _liquidationCostInAttoeth,
+				liquidatableDebtInAttodai: _liquidatableDebtInAttodai,
+				liquidationCostAtFeedPriceInAttoeth: _liquidationCostAtFeedPriceInAttoeth,
+				userOwned: true
+				});
+			++_matchCount;
+		}
+		return _cdps;
+	}
+
+	function cdpCount() public view returns (uint256 _cdpCount) {
+		return maker.cupi();
 	}
 }


### PR DESCRIPTION
Adds back the getCdps code mostly unmodified. Initial call calls into a function which first resolves the DSProxy from the user before calling the underlying function.

One issue is that, from an ABI standpoint, the getCdps is technically not a "view" function, because "maker.tab()" does some housekeeping. We should either accept that oddity, or emulate the logic behind `maker.tab()` to allow getCdps to be a real view.

```
 Error: Function declared as view, but this expression (potentially) modifies the state and thus requires non-payable (the default) or payable.
                        uint256 _debtInAttodai = maker.tab(bytes32(_i));
```
