### PR TITLE
Updates liquid long client library to be able to close positions.

### DIFF
--- a/client-library/library/package.json
+++ b/client-library/library/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@keydonix/liquid-long-client-library",
-	"version": "4.0.0",
+	"version": "5.0.0",
 	"description": "A client library for Liquid Long.",
 	"main": "output-node/index.js",
 	"browser": "output-es/index.js",

--- a/toolbox/libraries/ContractAccessor.ts
+++ b/toolbox/libraries/ContractAccessor.ts
@@ -2,17 +2,18 @@ import { Wallet } from 'ethers/wallet'
 import { JsonRpcProvider } from 'ethers/providers'
 import { LiquidLong, Address } from './liquid-long'
 import { ContractDependenciesEthers } from './liquid-long-ethers-impl'
-import { Tub, Sai, Oasis, ProxyRegistry, Gem } from '@keydonix/maker-contract-interfaces'
+import { Tub, Sai, Oasis, ProxyRegistry, Gem, Gov } from '@keydonix/maker-contract-interfaces'
 import { getEnv } from './Environment';
 
 export class ContractAccessor {
 	public readonly provider = new JsonRpcProvider(getEnv('ETHEREUM_HTTP', 'http://localhost:1235'))
-	public readonly wallet = new Wallet(getEnv('ETHEREUM_PRIVATE_KEY', '0xfae42052f82bed612a724fec3632f325f377120592c75bb78adfcceae6470c5a'), this.provider)
+	public readonly wallet = new Wallet(getEnv('ETHEREUM_PRIVATE_KEY', 'fae42052f82bed612a724fec3632f325f377120592c75bb78adfcceae6470c5a'), this.provider)
 	public readonly dependencies = new ContractDependenciesEthers(this.provider, this.wallet, async () => 1)
 	public readonly liquidLong = new LiquidLong(this.dependencies, Address.fromHexString(getEnv('ETHEREUM_LIQUID_LONG_ADDRESS', 'B03CF72BC5A9A344AAC43534D664917927367487')))
 	public readonly maker = new Tub(this.dependencies, Address.fromHexString(getEnv('ETHEREUM_MAKER_ADDRESS', '93943fb2d02ce1101dadc3ab1bc3cab723fd19d6')))
 	public readonly oasis = new Oasis(this.dependencies, Address.fromHexString(getEnv('ETHEREUM_OASIS_ADDRESS', '3c6721551c2ba3973560aef3e11d34ce05db4047')))
 	public readonly proxyRegistry = new ProxyRegistry(this.dependencies, Address.fromHexString(getEnv('ETHEREUM_PROXY_REGISTRY_ADDRESS', '4ddebcebe274751dfb129efc96a588a5242530ab')))
-	public readonly dai = new Sai(this.dependencies, Address.fromHexString('0x8C915Bd2C0df8Ba79A7D28538500a97bD15ea985'))
-	public readonly weth = new Gem(this.dependencies, Address.fromHexString('0xFCaf25bF38E7C86612a25ff18CB8e09aB07c9885'))
+	public readonly dai = new Sai(this.dependencies, Address.fromHexString('8C915Bd2C0df8Ba79A7D28538500a97bD15ea985'))
+	public readonly weth = new Gem(this.dependencies, Address.fromHexString('FCaf25bF38E7C86612a25ff18CB8e09aB07c9885'))
+	public readonly mkr = new Gov(this.dependencies, Address.fromHexString('25ff5dc79a7c4e34254ff0f4a19d69e491201dd3'))
 }

--- a/toolbox/scripts/seed-system.ts
+++ b/toolbox/scripts/seed-system.ts
@@ -2,12 +2,9 @@ import { ContractAccessor } from '../libraries/ContractAccessor'
 import { BigNumber, bigNumberify } from 'ethers/utils'
 import { Oasis, Address } from '@keydonix/maker-contract-interfaces';
 
-// TODO: read off Maker from env
-const DAI_ADDRESS = Address.fromHexString("0x8c915bd2c0df8ba79a7d28538500a97bd15ea985")
-const WETH_ADDRESS = Address.fromHexString("0xfcaf25bf38e7c86612a25ff18cb8e09ab07c9885")
-
 const ZERO = bigNumberify(0)
 const ETHER = bigNumberify(10).pow(bigNumberify(18))
+const contracts = new ContractAccessor()
 
 enum OrderType {
 	BID,
@@ -15,7 +12,7 @@ enum OrderType {
 }
 
 async function placeMultipleEqualOrders(od: Oasis<BigNumber>, orderType: OrderType, startPrice: BigNumber, endPrice: BigNumber, ethAmount: BigNumber, orderCount: number) {
-	const [payToken, buyToken] = (orderType == OrderType.ASK) ? [WETH_ADDRESS, DAI_ADDRESS] : [DAI_ADDRESS, WETH_ADDRESS]
+	const [payToken, buyToken] = (orderType == OrderType.ASK) ? [contracts.weth.address, contracts.dai.address] : [contracts.dai.address, contracts.weth.address]
 
 	const priceDelta = endPrice.sub(startPrice)
 	const orderEth = ethAmount.div(bigNumberify(orderCount))
@@ -30,17 +27,22 @@ async function placeMultipleEqualOrders(od: Oasis<BigNumber>, orderType: OrderTy
 }
 
 async function doStuff() {
-	const contracts = new ContractAccessor()
-
-	console.log('Sweeping Liquid Long ...')
+	console.log('Sweeping WETH ...')
 	const wethBalance = await contracts.weth.balanceOf_(contracts.liquidLong.address)
 	await contracts.liquidLong.wethWithdraw(wethBalance)
+
+	console.log('Sweeping MKR...')
+	await contracts.liquidLong.transferTokens(contracts.mkr.address)
 
 	console.log('Clearing Oasis orderbook...')
 	await clearOasisOrderbook(contracts.oasis, await contracts.liquidLong.weth_(), await contracts.liquidLong.dai_())
 
 	console.log('Adding ETH to Liquid Long...')
 	await contracts.liquidLong.wethDeposit(ETHER.mul(100))
+
+	console.log('Adding MKR to Liquid Long...')
+	await contracts.mkr.mint(contracts.liquidLong.address, ETHER.mul(100))
+
 
 	// TODO: check approvals/approve
 	console.log("Creating Oasis orders...")


### PR DESCRIPTION
This change required some contract changes, and I figured I would take the opportunity to make a couple quility of life contract changes while I was at it, since we need to re-deploy the contracts anyway.
1. Changed CDP ID input/output parameter to a number instead of bytes32.  Normally I would argue that the fact that it is a number is an implementation detail we should not rely on, unfortunately, we iterate it like a number, so we are tightly coupled with the implementation detail that is the ID selection algorithm.
2. Added an event for when CDPs are closed by the system.
3. Made closeCdp early return with result 0 when someone tries to close an empty CDP.  This is added mainly because the UI will sometimes do an off-chain closure attempt for an already closed CDP and having it not throw is a quality of life improvement.
4. Added the owner to the returned datastructure.  This is necessary so we know the address we need to use when doing the delegated closure call.

In the client library, the main change is the addition of closePosition and a minor bugfix when processing the `newCupEvent`.  There is some funky stuff with the nesting of the implementation.  This is so we can utilize the generated encoder/decoder to generate the delegated call and then forward the result.