### PR TITLE
An ugly hack.

### DIFF
--- a/client-library/library/package-lock.json
+++ b/client-library/library/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@keydonix/liquid-long-client-library",
-	"version": "4.0.0",
+	"version": "5.0.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/client-library/library/package.json
+++ b/client-library/library/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@keydonix/liquid-long-client-library",
-	"version": "5.0.0",
+	"version": "5.0.1",
 	"description": "A client library for Liquid Long.",
 	"main": "output-node/index.js",
 	"browser": "output-es/index.js",

--- a/client-library/library/source/liquid-long-ethers-impl.ts
+++ b/client-library/library/source/liquid-long-ethers-impl.ts
@@ -19,7 +19,7 @@ export class ContractDependenciesEthers implements Dependencies<ethers.utils.Big
 
 	call = async (transaction: Transaction<ethers.utils.BigNumber>): Promise<Uint8Array> => {
 		const ethersTransaction: ethers.providers.TransactionRequest = {
-			from: await this.signer.getAddress(),
+			from: await this.getSignerOrZero(),
 			to: transaction.to.to0xString(),
 			data: transaction.data.to0xString(),
 			value: transaction.value
@@ -78,6 +78,19 @@ export class ContractDependenciesEthers implements Dependencies<ethers.utils.Big
 	decodeLargeUnsignedInteger = (data: Bytes32): ethers.utils.BigNumber => new ethers.utils.BigNumber(data)
 
 	decodeLargeSignedInteger = (data: Bytes32): ethers.utils.BigNumber => new ethers.utils.BigNumber(data).fromTwos(256)
+
+	/**
+	 * Get the address of the signer, or zero if the signer address can't be fetched (for example, if privacy mode is enabled in the signing tool).
+	 *
+	 * FIXME: some functions may require a legitimate from address, while others do not. this information is known by the developer who calls the contract, but not known to the rest of the system. we need a way for the caller to specify, 'if a user address is not available, then fail, otherwise use the 0 address'
+	 */
+	private getSignerOrZero = async () => {
+		try {
+			return await this.signer.getAddress()
+		} catch (error) {
+			return new Address().to0xString()
+		}
+	}
 }
 
 /**


### PR DESCRIPTION
I really don't like this, but I'm practicing my _duct tape and bailing wire_ skills.  The fundamental problem is that the low level code has no way to know whether any given off-chain call will work properly without a valid sender (address 0 sender) or not.  The open UI works entirely without a valid sender, while some function calls made by the close UI don't.  The liquid-long-client-library knows, but it has no way to convey that information down the stack.  So, what we do is try to see if an address is available and use it as the sender if so, and if not fallback to the 0 address.

In the current interface, this will _probably_ work because the close UI doesn't currently support listing positions to close until you are logged in.  However, I would like to add the ability to view the website _without_ logging in by supplying an address in the query string, at which point there are a number of calls that will fail (like checking expected payout, which unfortunately requires a valid sender to execute).