### PR TITLE
Fetch pages of CDPs in parallel and support affiliate fees on close.

### DIFF
--- a/client-library/library/package.json
+++ b/client-library/library/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@keydonix/liquid-long-client-library",
-	"version": "5.0.1",
+	"version": "5.1.0",
 	"description": "A client library for Liquid Long.",
 	"main": "output-node/index.js",
 	"browser": "output-es/index.js",

--- a/client-library/library/source/liquid-long-ethers-impl.ts
+++ b/client-library/library/source/liquid-long-ethers-impl.ts
@@ -127,8 +127,8 @@ export class CloseDelegatingContractDependenciesEthers implements Dependencies<e
 	}
 
 	call = async (transaction: Transaction<ethers.utils.BigNumber>): Promise<Uint8Array> => {
-		// 082a7f79 is the signature hash for closeCDP method
-		if (transaction.data.toString().startsWith('dfaf3658')) {
+		// 082a7f79 is the signature hash for closeCdp(address,uint256,uint256,address) method
+		if (transaction.data.toString().startsWith('46fde171')) {
 			if (this.burned) throw new Error(`CloseDelegatingContractDependencies is designed to be used once and then discarded, you should not use it for multiple calls.`)
 			this.burned = true
 			const proxy = new DSProxy(this.stashingContractDependencies, this.delegatorAddress)
@@ -138,8 +138,8 @@ export class CloseDelegatingContractDependenciesEthers implements Dependencies<e
 		return await this.stashingContractDependencies.call(transaction)
 	}
 	submitTransaction = async (transaction: Transaction<ethers.utils.BigNumber>): Promise<TransactionReceipt>  => {
-		// 082a7f79 is the signature hash for closeCDP method
-		if (transaction.data.toString().startsWith('dfaf3658')) {
+		// 082a7f79 is the signature hash for closeCdp(address,uint256,uint256,address) method
+		if (transaction.data.toString().startsWith('46fde171')) {
 			if (this.burned) throw new Error(`CloseDelegatingContractDependencies is designed to be used once and then discarded, you should not use it for multiple calls.`)
 			this.burned = true
 			const proxy = new DSProxy(this.stashingContractDependencies, this.delegatorAddress)

--- a/client-library/library/source/liquid-long.ts
+++ b/client-library/library/source/liquid-long.ts
@@ -40,58 +40,58 @@ export class LiquidLong {
 		this.awaitReady = Promise.all([this.ethPriceInUsd.latest, this.providerFeeRate.latest]).then(() => {})
 	}
 
-	public shutdown = async (): Promise<void> => {
+	public readonly shutdown = async (): Promise<void> => {
 		await Promise.all([
 			this.ethPriceInUsd.shutdown(),
 			this.providerFeeRate.shutdown(),
 		])
 	}
 
-	public registerForMaxLeverageSizeUpdate = (listener: (newMaxLeverageSize: number) => void): void => {
+	public readonly registerForMaxLeverageSizeUpdate = (listener: (newMaxLeverageSize: number) => void): void => {
 		this.maxLeverageSizeInEth.registerListener(listener)
 	}
 
-	public registerForEthPriceUpdated = (listener: (newEthPriceInUsd: number) => void): void => {
+	public readonly registerForEthPriceUpdated = (listener: (newEthPriceInUsd: number) => void): void => {
 		this.ethPriceInUsd.registerListener(listener)
 	}
 
-	public getMaxLeverageSizeInEth = async (): Promise<number> => {
+	public readonly getMaxLeverageSizeInEth = async (): Promise<number> => {
 		return await this.maxLeverageSizeInEth.cached
 	}
 
-	public getEthPriceInUsd = async (): Promise<number> => {
+	public readonly getEthPriceInUsd = async (): Promise<number> => {
 		return await this.ethPriceInUsd.cached
 	}
 
-	public getLiquidationPriceInUsd = async (leverageMultiplier: number): Promise<number> => {
+	public readonly getLiquidationPriceInUsd = async (leverageMultiplier: number): Promise<number> => {
 		const ethPrice = await this.ethPriceInUsd.cached
 		const liquidationAsPercentOfPrice =  1.5 - 1.5 / leverageMultiplier
 		return ethPrice * liquidationAsPercentOfPrice
 	}
 
-	public getFuturePriceInUsdForPercentChange = async (percentChangeFromCurrent: number, leverageMultiplier: number): Promise<number> => {
+	public readonly getFuturePriceInUsdForPercentChange = async (percentChangeFromCurrent: number, leverageMultiplier: number): Promise<number> => {
 		const ethPrice = await this.ethPriceInUsd.cached
 		return ethPrice * (1 + percentChangeFromCurrent / leverageMultiplier)
 	}
 
-	public getPercentageChangeForFuturePrice = async (futurePriceInUsd: number, leverageMultiplier: number): Promise<number> => {
+	public readonly getPercentageChangeForFuturePrice = async (futurePriceInUsd: number, leverageMultiplier: number): Promise<number> => {
 		const ethPrice = await this.ethPriceInUsd.cached
 		return leverageMultiplier * (futurePriceInUsd / ethPrice - 1)
 	}
 
-	public getPositionValueInUsdAtFuturePrice = async (futurePriceInUsd: number, leverageMultiplier: number, leverageSizeInEth: number): Promise<number> => {
+	public readonly getPositionValueInUsdAtFuturePrice = async (futurePriceInUsd: number, leverageMultiplier: number, leverageSizeInEth: number): Promise<number> => {
 		const percentageChange = await this.getPercentageChangeForFuturePrice(futurePriceInUsd, leverageMultiplier)
 		const ethAtPrice = leverageSizeInEth + leverageSizeInEth * percentageChange
 		return ethAtPrice * await this.ethPriceInUsd.cached
 	}
 
-	public getChangeInPositionValueInUsdAtFuturePrice = async (futurePriceInUsd: number, leverageMultiplier: number, leverageSizeInEth: number): Promise<number> => {
+	public readonly getChangeInPositionValueInUsdAtFuturePrice = async (futurePriceInUsd: number, leverageMultiplier: number, leverageSizeInEth: number): Promise<number> => {
 		const currentPositionValueInUsd = await this.getPositionValueInUsdAtFuturePrice(await this.ethPriceInUsd.cached, leverageMultiplier, leverageSizeInEth)
 		const futurePositionValueInUsd =  await this.getPositionValueInUsdAtFuturePrice(futurePriceInUsd, leverageMultiplier, leverageSizeInEth)
 		return futurePositionValueInUsd - currentPositionValueInUsd
 	}
 
-	public getFeeInEth = async (leverageMultiplier: number, leverageSizeInEth: number): Promise<number> => {
+	public readonly getFeeInEth = async (leverageMultiplier: number, leverageSizeInEth: number): Promise<number> => {
 		const providerFeeRate = await this.providerFeeRate.cached
 		const loanInEth = this.getLoanSizeInEth(leverageMultiplier, leverageSizeInEth)
 		const feeInEth = loanInEth * providerFeeRate
@@ -99,12 +99,12 @@ export class LiquidLong {
 	}
 
 	// TODO verify this math with a run through of a liquidation
-	public getLiquidationPenaltyPercent = (leverageMultiplier: number): number => {
+	public readonly getLiquidationPenaltyPercent = (leverageMultiplier: number): number => {
 		const liquidationAsPercentOfPrice = 1.5 - 1.5 / leverageMultiplier
 		return leverageMultiplier * (liquidationAsPercentOfPrice * (1 - 0.13 / leverageMultiplier) - 1)
 	}
 
-	public getEstimatedCostsInEth = async (leverageMultiplier: number, leverageSizeInEth: number): Promise<{low: number, high: number}> => {
+	public readonly getEstimatedCostsInEth = async (leverageMultiplier: number, leverageSizeInEth: number): Promise<{low: number, high: number}> => {
 		const daiPerEth = await this.ethPriceInUsd.cached
 		const loanSizeInEth = this.getLoanSizeInEth(leverageMultiplier, leverageSizeInEth)
 		const daiToSell = loanSizeInEth * daiPerEth
@@ -120,33 +120,35 @@ export class LiquidLong {
 	/**
 	 * @returns null when there is not enough ETH available to buy with DAI on market
 	 */
-	public tryGetEstimatedCloseYieldInEth = async (cdpOwner: Address, cdpId: number): Promise<number> => {
-		const delegatorAddress: Address = cdpOwner
-		const delegatingDependencies = new CloseDelegatingContractDependenciesEthers(this.contractDependencies, delegatorAddress)
-		const delegatedContract = new LiquidLongContract(delegatingDependencies, this.contractAddress)
-		const estimatedYieldInAttoeth = await delegatedContract.closeCdp_(this.contractAddress, ethers.utils.bigNumberify(cdpId), ethers.utils.bigNumberify(0))
+	public readonly tryGetEstimatedCloseYieldInEth = async (cdpOwner: Address, cdpId: number): Promise<number> => {
+		const delegatedContract = this.getSingleUseCloseDelegator(cdpOwner)
+		const estimatedYieldInAttoeth = await delegatedContract.closeCdp_(this.contractAddress, ethers.utils.bigNumberify(cdpId), ethers.utils.bigNumberify(0), new Address())
 		return estimatedYieldInAttoeth.div(1e9).toNumber() / 1e9
 	}
 
-	public getPositions = async (holder: Address): Promise<Array<Position>> => {
+	public readonly getPositions = async (holder: Address): Promise<Array<Position>> => {
 		const numberOfCdps = await this.contract.cdpCount_()
-		const pageSize = 100
-		const positions: Array<Position> = []
+		const pageSize = 1000
+		const positionPromises: Array<Promise<Array<Position>>> = []
 		for (let i = 0; i < numberOfCdps; i += pageSize) {
-			const pageOfCdps = await this.contract.getCdps_(holder, i, pageSize)
-			const pageOfPositions = pageOfCdps.map(cdp => ({
-				id: cdp.id.toNumber(),
-				collateralInEth: cdp.lockedAttoeth.div(1e9).toNumber() / 1e9,
-				debtInDai: cdp.debtInAttodai.div(1e9).toNumber() / 1e9,
-				owner: cdp.owner,
-				proxied: !cdp.userOwned,
-			}))
-			positions.push(... pageOfPositions)
+			positionPromises.push(this.getPositionsChunk(holder, i, pageSize))
 		}
-		return positions
+		const positions = await Promise.all(positionPromises)
+		return positions.reduce((accumulator, currentValue) => accumulator.concat(currentValue), [])
 	}
 
-	public openPosition = async (leverageMultiplier: number, leverageSizeInEth: number, costLimitInEth: number, feeLimitInEth: number, affiliate?: Address): Promise<number> => {
+	public readonly getPositionsChunk = async (holder: Address, offset: number, pageSize: number): Promise<Array<Position>> => {
+		const pageOfCdps = await this.contract.getCdps_(holder, offset, pageSize)
+		return pageOfCdps.map(cdp => ({
+			id: cdp.id.toNumber(),
+			collateralInEth: cdp.lockedAttoeth.div(1e9).toNumber() / 1e9,
+			debtInDai: cdp.debtInAttodai.div(1e9).toNumber() / 1e9,
+			owner: cdp.owner,
+			proxied: !cdp.userOwned,
+		}))
+	}
+
+	public readonly openPosition = async (leverageMultiplier: number, leverageSizeInEth: number, costLimitInEth: number, feeLimitInEth: number, affiliate?: Address): Promise<number> => {
 		const leverageMultiplierInPercents = ethers.utils.bigNumberify(Math.round(leverageMultiplier * 100))
 		const leverageSizeInAttoeth = ethers.utils.bigNumberify(Math.round(leverageSizeInEth * 1e9)).mul(1e9)
 		const allowedCostInAttoeth = ethers.utils.bigNumberify(Math.round(costLimitInEth * 1e9)).mul(1e9)
@@ -157,56 +159,64 @@ export class LiquidLong {
 		const newCupEvent = <LiquidLongContract.NewCup<ethers.utils.BigNumber>>events.find(x => x.name === 'NewCup')
 		if (!newCupEvent) throw new Error(`Expected 'newCup' event when calling 'openCdp' but no such event found.`)
 		if (!newCupEvent.parameters || !newCupEvent.parameters.user || !newCupEvent.parameters.cup) throw new Error(`Unexpected contents for the 'NewCup' event.\n${newCupEvent}`)
-		return Number.parseInt(newCupEvent.parameters.cup.toString(), 16)
+		return newCupEvent.parameters.cup.toNumber()
 	}
 
-	public closePosition = async (cdpOwner: Address, cdpId: number, minimumPayoutInEth: number): Promise<void> => {
-		const delegatorAddress: Address = cdpOwner
-		const delegatingDependencies = new CloseDelegatingContractDependenciesEthers(this.contractDependencies, delegatorAddress)
-		const delegatedContract = new LiquidLongContract(delegatingDependencies, this.contractAddress)
+	public readonly closePosition = async (cdpOwner: Address, cdpId: number, minimumPayoutInEth: number, affiliate?: Address): Promise<void> => {
+		const delegatedContract = this.getSingleUseCloseDelegator(cdpOwner)
 		const minimumPayoutInAttoeth = ethers.utils.bigNumberify(Math.floor(minimumPayoutInEth * 1e9)).mul(1e9)
-		const events = await delegatedContract.closeCdp(this.contractAddress, ethers.utils.bigNumberify(cdpId), minimumPayoutInAttoeth)
+		const affiliateAddress = affiliate || new Address()
+		const events = await delegatedContract.closeCdp(this.contractAddress, ethers.utils.bigNumberify(cdpId), minimumPayoutInAttoeth, affiliateAddress)
 		const closeCupEvent = <LiquidLongContract.CloseCup<ethers.utils.BigNumber>>events.find(x => x.name === 'CloseCup')
 		if (!closeCupEvent) throw new Error(`Expected 'closeCup' event when calling 'closeCdp' but no such event found.`)
 		if (!closeCupEvent.parameters || !closeCupEvent.parameters.user) throw new Error(`Unexpected contents for the 'CloseCup' event.\n${closeCupEvent}`)
 	}
 
-	public adminDepositEth = async (amount: number): Promise<void> => {
+	public readonly adminDepositEth = async (amount: number): Promise<void> => {
 		const attachedAttoeth = ethers.utils.bigNumberify(Math.round(amount * 1e9)).mul(1e9)
 		await this.contract.wethDeposit(attachedAttoeth)
 	}
 
-	public adminWithdrawWeth = async (amount: number): Promise<void> => {
+	public readonly adminWithdrawWeth = async (amount: number): Promise<void> => {
 		await this.contract.wethWithdraw(ethers.utils.bigNumberify(Math.round(amount * 1e9)).mul(1e9))
 	}
 
-	public adminTransferOwnership = async (newOwner: Address): Promise<void> => {
+	public readonly adminWithdrawMkr = async (): Promise<void> => {
+		await this.contract.transferTokens(await this.contract.mkr_())
+	}
+
+	public readonly adminTransferOwnership = async (newOwner: Address): Promise<void> => {
 		await this.contract.transferOwnership(newOwner)
 	}
 
-	public adminAcceptOwnership = async (): Promise<void> => {
+	public readonly adminAcceptOwnership = async (): Promise<void> => {
 		await this.contract.claimOwnership()
 	}
 
-	private fetchMaxLeverageSizeInEth = async (): Promise<number> => {
+	private readonly fetchMaxLeverageSizeInEth = async (): Promise<number> => {
 		const attoweth = await this.contract.attowethBalance_()
 		return attoweth.div(2).div(1e9).toNumber() / 1e9
 	}
 
-	private fetchEthPriceInUsd = async (): Promise<number> => {
+	private readonly fetchEthPriceInUsd = async (): Promise<number> => {
 		const attousd = await this.contract.ethPriceInUsd_()
 		return attousd.div(1e9).toNumber() / 1e9
 	}
 
-	private fetchProviderFeeRate = async (): Promise<number> => {
+	private readonly fetchProviderFeeRate = async (): Promise<number> => {
 		const providerFeeAttoethPerEth = await this.contract.providerFeePerEth_()
 		return providerFeeAttoethPerEth.div(1e9).toNumber() / 1e9
 	}
 
-	private getLoanSizeInEth = (leverageMultiplier: number, leverageSizeInEth: number): number => {
+	private readonly getLoanSizeInEth = (leverageMultiplier: number, leverageSizeInEth: number): number => {
 		const ethLockedInCdp = leverageSizeInEth * leverageMultiplier
 		const loanInEth = ethLockedInCdp - leverageSizeInEth
 		return loanInEth
+	}
+
+	private readonly getSingleUseCloseDelegator = (proxy: Address): LiquidLongContract<ethers.utils.BigNumber> => {
+		const delegatingDependencies = new CloseDelegatingContractDependenciesEthers(this.contractDependencies, proxy)
+		return new LiquidLongContract(delegatingDependencies, this.contractAddress)
 	}
 }
 


### PR DESCRIPTION
* Made getPositions operate in parallel instead of synchronously.
* Added library support for accepting affiliate fees on close.
* Marked all library methods as readonly (they always should have been, I was just lazy before).
* Factored the delegatedContract instantiator into a private method and gave it a name that makes it more clear that you shouldn't reuse it.
* Created an integration test for closure.
* Addressed a couple TODOs in the integration tests including writing a test for opening 1x leverage positions and doing setup/cleanup between each test.