### PR TITLE
Adds support for passing in an undefined or dynamic gas price.

### DIFF
--- a/client-library/integration-tests/package-lock.json
+++ b/client-library/integration-tests/package-lock.json
@@ -9,7 +9,7 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "10.12.18",
+					"version": "10.5.8",
 					"bundled": true
 				},
 				"aes-js": {
@@ -70,6 +70,10 @@
 					"version": "1.0.1",
 					"bundled": true
 				},
+				"recursive-fs": {
+					"version": "1.1.1",
+					"bundled": true
+				},
 				"scrypt-js": {
 					"version": "2.0.4",
 					"bundled": true
@@ -79,7 +83,7 @@
 					"bundled": true
 				},
 				"typescript": {
-					"version": "3.0.0-rc",
+					"version": "3.3.3",
 					"bundled": true
 				},
 				"uuid": {

--- a/client-library/integration-tests/source/integration.ts
+++ b/client-library/integration-tests/source/integration.ts
@@ -52,13 +52,13 @@ describe('liquid long tests', async () => {
 			affiliate: Wallet.fromMnemonic('fantasy fringe prosper bench jaguar sound corn course stick blade luggage wonder').connect(provider),
 		}
 		liquidLong = {
-			owner: LiquidLong.createJsonRpc(ethereumAddress, liquidLongAddress, 0, 10),
-			user: new LiquidLong(new TimeoutScheduler(), provider, wallets.user, liquidLongAddress, 0),
-			affiliate: new LiquidLong(new TimeoutScheduler(), provider, wallets.affiliate, liquidLongAddress, 0),
+			owner: LiquidLong.createJsonRpc(ethereumAddress, liquidLongAddress, async () => 0, 10),
+			user: new LiquidLong(new TimeoutScheduler(), provider, wallets.user, liquidLongAddress, async () => 0),
+			affiliate: new LiquidLong(new TimeoutScheduler(), provider, wallets.affiliate, liquidLongAddress, async () => 0),
 		}
-		const ownerDependencies = new ContractDependenciesEthers(provider, provider.getSigner(0), async () => 1)
-		const userDependencies = new ContractDependenciesEthers(provider, wallets.user, async () => 1)
-		const affiliateDependencies = new ContractDependenciesEthers(provider, wallets.affiliate, async () => 1)
+		const ownerDependencies = new ContractDependenciesEthers(provider, provider.getSigner(0), async () => 0)
+		const userDependencies = new ContractDependenciesEthers(provider, wallets.user, async () => 0)
+		const affiliateDependencies = new ContractDependenciesEthers(provider, wallets.affiliate, async () => 0)
 		// TODO: turn these into objects like weth
 		oasis = new Oasis(ownerDependencies, oasisAddress)
 		maker = new Tub(ownerDependencies, makerAddress)

--- a/client-library/library/package-lock.json
+++ b/client-library/library/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@keydonix/liquid-long-client-library",
-	"version": "5.1.0",
+	"version": "6.0.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/client-library/library/package.json
+++ b/client-library/library/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@keydonix/liquid-long-client-library",
-	"version": "5.1.0",
+	"version": "6.0.0",
 	"description": "A client library for Liquid Long.",
 	"main": "output-node/index.js",
 	"browser": "output-es/index.js",

--- a/client-library/library/source/liquid-long.ts
+++ b/client-library/library/source/liquid-long.ts
@@ -14,25 +14,25 @@ export class LiquidLong {
 	private readonly providerFeeRate: PolledValue<number>
 	public readonly awaitReady: Promise<void>
 
-	static createWeb3(web3Provider: ethers.providers.AsyncSendable, liquidLong: Address, defaultGasPriceInNanoeth: number, web3PollingInterval: number, ethPricePollingFrequency?: number, serviceFeePollingFrequency?: number): LiquidLong {
+	static createWeb3(web3Provider: ethers.providers.AsyncSendable, liquidLong: Address, getGasPriceInNanoeth: () => Promise<number|undefined>, web3PollingInterval: number, ethPricePollingFrequency?: number, serviceFeePollingFrequency?: number): LiquidLong {
 		const scheduler = new TimeoutScheduler()
 		const provider = new ethers.providers.Web3Provider(web3Provider)
 		const signer = provider.getSigner(0)
 		provider.pollingInterval = web3PollingInterval
-		return new LiquidLong(scheduler, provider, signer, liquidLong, defaultGasPriceInNanoeth, ethPricePollingFrequency, serviceFeePollingFrequency)
+		return new LiquidLong(scheduler, provider, signer, liquidLong, getGasPriceInNanoeth, ethPricePollingFrequency, serviceFeePollingFrequency)
 	}
 
-	static createJsonRpc(jsonRpcUrl: string, liquidLong: Address, defaultGasPriceInNanoeth: number, jsonRpcPollingInterval: number, ethPricePollingFrequency?: number, serviceFeePollingFrequency?: number): LiquidLong {
+	static createJsonRpc(jsonRpcUrl: string, liquidLong: Address, getGasPriceInNanoeth: () => Promise<number|undefined>, jsonRpcPollingInterval: number, ethPricePollingFrequency?: number, serviceFeePollingFrequency?: number): LiquidLong {
 		const scheduler = new TimeoutScheduler()
 		const provider = new ethers.providers.JsonRpcProvider(jsonRpcUrl);
 		const signer = provider.getSigner(0)
 		provider.pollingInterval = jsonRpcPollingInterval
-		return new LiquidLong(scheduler, provider, signer, liquidLong, defaultGasPriceInNanoeth, ethPricePollingFrequency, serviceFeePollingFrequency)
+		return new LiquidLong(scheduler, provider, signer, liquidLong, getGasPriceInNanoeth, ethPricePollingFrequency, serviceFeePollingFrequency)
 	}
 
-	public constructor(scheduler: Scheduler, provider: Provider, signer: Signer, liquidLong: Address, defaultGasPriceInNanoeth: number, ethPricePollingFrequency: number = 10000, providerFeePollingFrequency: number = 10000) {
+	public constructor(scheduler: Scheduler, provider: Provider, signer: Signer, liquidLong: Address, getGasPriceInNanoeth: () => Promise<number|undefined>, ethPricePollingFrequency: number = 10000, providerFeePollingFrequency: number = 10000) {
 		this.contractAddress = liquidLong
-		this.contractDependencies = new ContractDependenciesEthers(provider, signer, async () => defaultGasPriceInNanoeth)
+		this.contractDependencies = new ContractDependenciesEthers(provider, signer, getGasPriceInNanoeth)
 		this.contract = new LiquidLongContract(this.contractDependencies, liquidLong)
 		this.maxLeverageSizeInEth = new PolledValue(scheduler, this.fetchMaxLeverageSizeInEth, ethPricePollingFrequency)
 		this.ethPriceInUsd = new PolledValue(scheduler, this.fetchEthPriceInUsd, ethPricePollingFrequency)

--- a/client-library/tests/source/liquid-long-tests.ts
+++ b/client-library/tests/source/liquid-long-tests.ts
@@ -15,7 +15,7 @@ describe('LiquidLong', async () => {
 		mockScheduler = new MockScheduler()
 		mockProvider = new MockProvider()
 		mockSigner = new MockSigner()
-		liquidLong = new LiquidLong(mockScheduler, mockProvider, mockSigner, new Address(), 1, 0.01, 1)
+		liquidLong = new LiquidLong(mockScheduler, mockProvider, mockSigner, new Address(), async () => 0, 0.01, 1)
 	})
 
 	afterEach(async () => {


### PR DESCRIPTION
Client-library users can now supply a gas price that is calculated at execution time (e.g., from ethgasstation) or they can supply undefined in which case the `gasPrice` will be left off of the transaction so the signer (e.g., MetaMask) can pick it.